### PR TITLE
Add sendNotificationMessage hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Notification Center Changelog
 ===========================
 
+Version 1.3.0 (2015-??-??)
+---------------------------------
+
+### Fixed
+- Do not add a new line if file storage mode append but existing file was empty
+
+
 Version 1.3.0-rc1 (2015-07-07)
 ---------------------------------
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ if (null !== $objNotificationCollection) {
 
 ## Hooks
 
-If you want to enrich each message being send by some meta data or want to disable some messages being sent, you can
+If you want to enrich each message being sent by some meta data or want to disable some messages being sent, you can
 use the sendNotificationMessage hook:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -58,3 +58,33 @@ if (null !== $objNotificationCollection) {
     }
 }
 ```
+
+## Hooks
+
+If you want to enrich each message being send by some meta data or want to disable some messages being sent, you can
+use the sendNotificationMessage hook:
+
+```php
+
+// config.php
+$GLOBALS['TL_HOOKS']['sendNotificationMessage'][] = array('MyHook', 'execute');
+
+// The hook
+class MyHook
+{
+    public function execute($objMessage, $arrTokens, $language, $objGatewayModel)
+    {
+         if (!$objMessage->regardUserSettings || !FE_USER_LOGGED_IN 
+            || $objMessage->getRelated('pid')->type !== 'custom_notification') {
+            return true;
+         }
+         
+         $user = \MemberModel::findByPK($arrTokens['recipient']);     
+         if (!$user || !$user->disableEmailNotifications) {
+            return true;
+         }
+                      
+         return false;
+    }
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require":{
         "php":">=5.3.2",
         "contao/core":"^3.2",
-        "contao-community-alliance/composer-installer":"2.*",
+        "contao-community-alliance/composer-plugin":"2.*",
         "terminal42/contao-namespace-class-loader":"^1.0.1",
         "codefog/contao-haste":"4.*",
         "terminal42/dcawizard":"2.*"

--- a/library/NotificationCenter/Gateway/File.php
+++ b/library/NotificationCenter/Gateway/File.php
@@ -173,7 +173,11 @@ class File extends Base implements GatewayInterface
 
         $objFile = new \File($this->objModel->file_path . '/' . $strFileName);
 
-        if ($strStorageMode === self::FILE_STORAGE_APPEND) {
+        // Don't start with a newline
+        if ($strStorageMode === self::FILE_STORAGE_APPEND
+            && $objFile->exists()
+            && $objFile->getContent() !== ''
+        ) {
             $strContent = $objFile->getContent() . "\n" . $strContent;
         }
 
@@ -223,7 +227,10 @@ class File extends Base implements GatewayInterface
             $fileContents = ob_get_contents();
             ob_end_clean();
 
-            $strContent .= $fileContents . "\n" . $strContent;
+            // Don't start with a newline
+            if ($fileContents !== '') {
+                $strContent .= $fileContents . "\n" . $strContent;
+            }
         }
 
         // Write content to temporary file


### PR DESCRIPTION
This pull request provides a hook before sending a message.

I'm using the notification center in an application which sends a notification when something happens. This notification creates different messages for different persons.  For example a `productWasOrdered` notifcation would send different messages to the product owner, the user who ordered the product and the system administrator.

The product owner has the option to disable such email notifications in his profile. To respect his user settings the hook is required. 

Alternatively I would have to create different notifications for each receiver and handle the settings when creating the notification. But this would limit the flexibility which the notification center claims to provide.