### PR TITLE
Allow recipient token to contain a list of recipients.

### DIFF
--- a/library/NotificationCenter/Util/String.php
+++ b/library/NotificationCenter/Util/String.php
@@ -149,6 +149,8 @@ class String
      */
     public static function compileRecipients($strRecipients, $arrTokens)
     {
+        // Replaces tokens first so that tokens can contain a list of recipients.
+        $strRecipients = static::recursiveReplaceTokensAndTags($strRecipients, $arrTokens, static::NO_TAGS | static::NO_BREAKS);
         $arrRecipients = array();
 
         foreach ((array) trimsplit(',', $strRecipients) as $strAddress) {


### PR DESCRIPTION
This pull request adds the feature that a token can contain a list of recipients (See #71).

Why is it useful: Image you have an product where users add comments. Each user who added a comment can subscribe for changes. So when a new comment is added, only one notification can be sent containing a message to the admin and the message for the subscribers.
