### PR TITLE
If "Save file" is activated, the file will not be sent as an attachment.

### DIFF
--- a/library/NotificationCenter/Util/Form.php
+++ b/library/NotificationCenter/Util/Form.php
@@ -25,6 +25,11 @@ class Form
     {
         if (!is_uploaded_file($file['tmp_name'])) {
 
+            if(file_exists($file['tmp_name'])) {
+                $basePath = \Environment::get('documentRoot') . TL_PATH . "/";
+                return str_replace($basePath, '', str_replace('\\', '/',$file['tmp_name'] ));
+            }
+
             return null;
         }
 

--- a/library/NotificationCenter/Util/Form.php
+++ b/library/NotificationCenter/Util/Form.php
@@ -26,10 +26,9 @@ class Form
         if (!is_uploaded_file($file['tmp_name'])) {
 
             if(file_exists($file['tmp_name'])) {
-                $basePath = \Environment::get('documentRoot') . TL_PATH . "/";
-                return str_replace($basePath, '', str_replace('\\', '/',$file['tmp_name'] ));
+                $basePath = TL_ROOT . "/";
+                return str_replace($basePath, '', $file['tmp_name'] );
             }
-
             return null;
         }
 


### PR DESCRIPTION
By shortening the absolute file path, the file can be sent as an attachment.