### PR TITLE
Handle Unicode characters in tokens

### DIFF
--- a/library/NotificationCenter/Model/QueuedMessage.php
+++ b/library/NotificationCenter/Model/QueuedMessage.php
@@ -26,7 +26,7 @@ class QueuedMessage extends \Model
      */
     public function setTokens($arrTokens)
     {
-        $this->tokens = json_encode($arrTokens);
+        $this->tokens = json_encode($arrTokens, JSON_UNESCAPED_UNICODE);
 
         return $this;
     }


### PR DESCRIPTION
In some cases, tokens are filled with questionable unicode data. Such data was encoded as

```json
{"name":"G\u00fcnther"}
```

I found that using an option to `json_encode` the unicode characters were correctly displayed in the email later on.