### PR TITLE
Personalized messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ if (null !== $objNotificationCollection) {
 }
 ```
 
+## Sending a personalized notification
+
+Extension developers can also send a personalized notification. Messages which supports personalization will be sent
+for each personalized contact.
+
+```php
+$arrTokens             = array('receiver_email' => 'admin@example.com', 'message' => 'text');
+$arrPersonalizedTokens = array(
+    array('receiver_email' => 'foo@example.com'),
+    array('receiver_email' => 'bar@example.com'),
+);
+    
+$objNotification = NotificationCenter\Model\Notification::findByPk($intNotificationId);
+if (null !== $objNotification) {
+    // Each personalized record get merged before sending personalized message
+    $objNotification->sendPersonalized($arrTokens, $arrPersonalizedTokens, $strLanguage); // Language is optional
+}
+```
+
 ## Hooks
 
 If you want to enrich each message being sent by some meta data or want to disable some messages being sent, you can

--- a/dca/tl_nc_message.php
+++ b/dca/tl_nc_message.php
@@ -112,10 +112,10 @@ $GLOBALS['TL_DCA']['tl_nc_message'] = array
     'palettes' => array
     (
         '__selector__'                => array('gateway_type'),
-        'default'                     => '{title_legend},title,gateway;',
-        'email'                       => '{title_legend},title,gateway;{languages_legend},languages;{expert_legend:hide},email_priority,email_template;{publish_legend},published',
-        'file'                        => '{title_legend},title,gateway;{languages_legend},languages;{publish_legend},published',
-        'postmark'                    => '{title_legend},title,gateway;{languages_legend},languages;{expert_legend:hide},postmark_tag,postmark_trackOpens;{publish_legend},published',
+        'default'                     => '{title_legend},title,gateway,personalized;',
+        'email'                       => '{title_legend},title,gateway,personalized;{languages_legend},languages;{expert_legend:hide},email_priority,email_template;{publish_legend},published',
+        'file'                        => '{title_legend},title,gateway,personalized;{languages_legend},languages;{publish_legend},published',
+        'postmark'                    => '{title_legend},title,gateway,personalized;{languages_legend},languages;{expert_legend:hide},postmark_tag,postmark_trackOpens;{publish_legend},published',
     ),
 
     // Fields
@@ -219,6 +219,14 @@ $GLOBALS['TL_DCA']['tl_nc_message'] = array
             'exclude'                 => true,
             'inputType'               => 'checkbox',
             'eval'                    => array('tl_class'=>'w50 m12'),
+            'sql'                     => "char(1) NOT NULL default ''"
+        ),
+        'personalized' => array
+        (
+            'exclude'                 => true,
+            'label'                   => &$GLOBALS['TL_LANG']['tl_nc_message']['personalized'],
+            'inputType'               => 'checkbox',
+            'eval'                    => array('tl_class'=>'w50'),
             'sql'                     => "char(1) NOT NULL default ''"
         ),
         'published' => array

--- a/languages/en/tl_nc_message.php
+++ b/languages/en/tl_nc_message.php
@@ -18,6 +18,7 @@ $GLOBALS['TL_LANG']['tl_nc_message']['email_priority']          = array('Priorit
 $GLOBALS['TL_LANG']['tl_nc_message']['email_template']          = array('Template file', 'Please choose a template file.');
 $GLOBALS['TL_LANG']['tl_nc_message']['postmark_tag']            = array('Tag', 'Here you can enter the tag.');
 $GLOBALS['TL_LANG']['tl_nc_message']['postmark_trackOpens']     = array('Enable open tracking', 'Here you can enable open tracking.');
+$GLOBALS['TL_LANG']['tl_nc_message']['personalized']            = array('Support personalization', 'If enabled and a personalized notification is sent, send this message for each personalized contact.');
 $GLOBALS['TL_LANG']['tl_nc_message']['published']               = array('Publish message', 'Include this message when a notification is being sent.');
 
 /**

--- a/library/NotificationCenter/Model/Message.php
+++ b/library/NotificationCenter/Model/Message.php
@@ -55,6 +55,30 @@ class Message extends \Model
     }
 
     /**
+     * Send this message personalized if supported using its gateway
+     * @param   array
+     * @param   array
+     * @param   string
+     * @return  array
+     */
+    public function sendPersonalized(array $arrTokens, array $arrPersonalized, $strLanguage = '')
+    {
+        $arrSuccess = array();
+
+        if ($this->personalized == '') {
+            $arrSuccess[] = $this->send($arrTokens, $strLanguage);
+        } else {
+            foreach ($arrPersonalized as $arrPerson) {
+                $arrPersonalizedTokens = array_merge($arrTokens, $arrPerson);
+
+                $arrSuccess[] = $this->send($arrPersonalizedTokens, $strLanguage);
+            }
+        }
+
+        return $arrSuccess;
+    }
+
+    /**
      * Find all published by notification
      * @param   Notification
      * @return  Message|null

--- a/library/NotificationCenter/Model/Notification.php
+++ b/library/NotificationCenter/Model/Notification.php
@@ -53,6 +53,31 @@ class Notification extends \Model
     }
 
     /**
+     * Sends a personalized notification
+     * @param   array   The tokens
+     * @param   array   List of personalized tokens
+     * @param   string  The language (optional)
+     * @return  array
+     */
+    public function sendPersonalized(array $arrTokens, array $arrPersonalized, $strLanguage = '')
+    {
+        // Check if there are valid messages
+        if (($objMessages = $this->getMessages()) === null) {
+            \System::log('Could not find any messages for notification ID ' . $this->id, __METHOD__, TL_ERROR);
+
+            return array();
+        }
+
+        $arrResult = array();
+
+        foreach ($objMessages as $objMessage) {
+            $arrResult[$objMessage->id] = $objMessage->sendPersonalized($arrTokens, $arrPersonalized, $strLanguage);
+        }
+
+        return $arrResult;
+    }
+
+    /**
      * Find notification group for type
      * @param   string Type
      * @return  string Class


### PR DESCRIPTION
This pull request provides a new way to send personalized notifications. It provides more flexibility for 3rd party developers who have to deal with following scenario:

 - Comment was added to a post
 - The admin should get an notification
 - The post author should get a notification
 - Each post subscriber should get informed with a personalized message

The personalization can be enabled for each message. So it's possible to send one notification for the given scenario.

This feature could also be implemented by adding another param to the `send` method.