### PR TITLE
Adds the "mapNotificationTokens" hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ if (null !== $objNotificationCollection) {
 
 ## Hooks
 
+### `sendNotificationMessage`
+
 If you want to enrich each message being sent by some meta data or want to disable some messages being sent, you can
-use the sendNotificationMessage hook:
+use the `sendNotificationMessage` hook:
 
 ```php
 
@@ -74,20 +76,22 @@ class MyHook
 {
     public function execute($objMessage, $arrTokens, $language, $objGatewayModel)
     {
-         if (!$objMessage->regardUserSettings || !FE_USER_LOGGED_IN 
+        if (!$objMessage->regardUserSettings || !FE_USER_LOGGED_IN 
             || $objMessage->getRelated('pid')->type !== 'custom_notification') {
             return true;
-         }
+        }
          
-         $user = \MemberModel::findByPK($arrTokens['recipient']);     
-         if (!$user || !$user->disableEmailNotifications) {
+        $user = \MemberModel::findByPK($arrTokens['recipient']);     
+        if (!$user || !$user->disableEmailNotifications) {
             return true;
-         }
+        }
                       
-         return false;
+        return false;
     }
 }
 ```
+
+### `mapNotificationTokens`
 
 You can modify the tokens of a message via the `mapNotificationTokens` hook. It is executed before the `sendNotificationMessage` hook and receives the same parameters. The hook expects its listeners to return an array of modified tokens:
 

--- a/README.md
+++ b/README.md
@@ -88,3 +88,28 @@ class MyHook
     }
 }
 ```
+
+You can modify the tokens of a message via the `mapNotificationTokens` hook. It is executed before the `sendNotificationMessage` hook and receives the same parameters. The hook expects its listeners to return an array of modified tokens:
+
+```php
+// Example: Escape all commas in tokens of a CSV export by wrapping the token in double quotes. Also escape existing double quotes inside the token.
+
+// config.php
+$GLOBALS['TL_HOOKS']['mapNotificationTokens'][] = array('MyHook', 'execute');
+
+// The hook
+class MyHook
+{
+    public function execute($objMessage, $arrTokens, $language, $objGatewayModel)
+    {
+        if ($objGatewayModel->type === 'file' && $objGatewayModel->file_type === 'csv') {
+            array_walk($arrTokens, function(&$varValue) {
+                if (strpos($varValue, ',') !== false)
+                    $varValue = '"' . str_replace('"', '""', $varValue) . '"';
+            });
+        }
+
+        return $arrTokens;
+    }
+}
+```

--- a/library/NotificationCenter/Model/Message.php
+++ b/library/NotificationCenter/Model/Message.php
@@ -43,7 +43,7 @@ class Message extends \Model
 
         if (isset($GLOBALS['TL_HOOKS']['sendNotificationMessage']) && is_array($GLOBALS['TL_HOOKS']['sendNotificationMessage'])) {
             foreach ($GLOBALS['TL_HOOKS']['sendNotificationMessage'] as $arrCallback) {
-                $blnSuccess = \System::importStatic($arrCallback[0])->$arrCallback[1]($this, $arrTokens, $strLanguage, $objGatewayModel);
+                $blnSuccess = \System::importStatic($arrCallback[0])->{$arrCallback[1]}($this, $arrTokens, $strLanguage, $objGatewayModel);
 
                 if (!$blnSuccess) {
                     return false;

--- a/library/NotificationCenter/Model/Message.php
+++ b/library/NotificationCenter/Model/Message.php
@@ -41,6 +41,12 @@ class Message extends \Model
             return false;
         }
 
+        if (isset($GLOBALS['TL_HOOKS']['mapNotificationTokens']) && is_array($GLOBALS['TL_HOOKS']['mapNotificationTokens'])) {
+            foreach ($GLOBALS['TL_HOOKS']['mapNotificationTokens'] as $arrCallback) {
+                $arrTokens = \System::importStatic($arrCallback[0])->{$arrCallback[1]}($this, $arrTokens, $strLanguage, $objGatewayModel);
+            }
+        }
+
         if (isset($GLOBALS['TL_HOOKS']['sendNotificationMessage']) && is_array($GLOBALS['TL_HOOKS']['sendNotificationMessage'])) {
             foreach ($GLOBALS['TL_HOOKS']['sendNotificationMessage'] as $arrCallback) {
                 $blnSuccess = \System::importStatic($arrCallback[0])->{$arrCallback[1]}($this, $arrTokens, $strLanguage, $objGatewayModel);


### PR DESCRIPTION
Adds the `mapNotificationTokens` hook to make independent token manipulation possible as suggested in #105.
Includes duplicate of #104, that can be ignored.