### PR TITLE
add pattern parameter field at form definition

### DIFF
--- a/classes/tl_form.php
+++ b/classes/tl_form.php
@@ -3,8 +3,9 @@
 /**
  * notification_center extension for Contao Open Source CMS
  *
- * @copyright  Copyright (c) 2008-2015, terminal42
+ * @copyright  Copyright (c) 2008-2016, terminal42
  * @author     terminal42 gmbh <info@terminal42.ch>
+ * @author     Ingolf Steinhardt <info@e-spin.de> 
  * @license    LGPL
  */
 
@@ -77,14 +78,15 @@ class tl_form extends \Backend
     {
         $arrTokens = array();
         $arrTokens['raw_data'] = '';
+        $strPattern = $arrForm['nc_flatten_pattern'] ?: ', ';
 
         foreach ($arrData as $k => $v) {
-            \Haste\Util\StringUtil::flatten($v, 'form_'.$k, $arrTokens);
-            $arrTokens['raw_data'] .= (isset($arrLabels[$k]) ? $arrLabels[$k] : ucfirst($k)) . ': ' . (is_array($v) ? implode(', ', $v) : $v) . "\n";
+            \Haste\Util\StringUtil::flatten($v, 'form_'.$k, $arrTokens, $strPattern);
+            $arrTokens['raw_data'] .= (isset($arrLabels[$k]) ? $arrLabels[$k] : ucfirst($k)) . ': ' . (is_array($v) ? implode($strPattern, $v) : $v) . "\n";
         }
 
         foreach ($arrForm as $k => $v) {
-            \Haste\Util\StringUtil::flatten($v, 'formconfig_'.$k, $arrTokens);
+            \Haste\Util\StringUtil::flatten($v, 'formconfig_'.$k, $arrTokens, $strPattern);
         }
 
         // Administrator e-mail
@@ -108,7 +110,7 @@ class tl_form extends \Backend
      * @deprecated Deprecated since version 1.3.1, to be removed in version 2.
      *             Use Haste\Util\StringUtil::flatten() instead.
      */
-    public function flatten($varValue, $strKey, &$arrData)
+    public function flatten($varValue, $strKey, &$arrData, $strPattern)
     {
         if (is_object($varValue)) {
             return;
@@ -129,6 +131,6 @@ class tl_form extends \Backend
             }
         }
 
-        $arrData[$strKey] = implode(', ', $arrValues);
+        $arrData[$strKey] = implode($strPattern, $arrValues);
     }
 }

--- a/dca/tl_form.php
+++ b/dca/tl_form.php
@@ -3,15 +3,16 @@
 /**
  * notification_center extension for Contao Open Source CMS
  *
- * @copyright  Copyright (c) 2008-2015, terminal42
+ * @copyright  Copyright (c) 2008-2016, terminal42
  * @author     terminal42 gmbh <info@terminal42.ch>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
  * @license    LGPL
  */
 
 /**
  * Palettes
  */
-$GLOBALS['TL_DCA']['tl_form']['palettes']['default'] = str_replace('sendViaEmail;', 'nc_notification,sendViaEmail;', $GLOBALS['TL_DCA']['tl_form']['palettes']['default']);
+$GLOBALS['TL_DCA']['tl_form']['palettes']['default'] = str_replace('sendViaEmail;', 'nc_notification,nc_flatten_pattern,sendViaEmail;', $GLOBALS['TL_DCA']['tl_form']['palettes']['default']);
 
 /**
  * Fields
@@ -22,6 +23,15 @@ $GLOBALS['TL_DCA']['tl_form']['fields']['nc_notification'] = array
     'exclude'                   => true,
     'inputType'                 => 'select',
     'options_callback'          => array('NotificationCenter\tl_form', 'getNotificationChoices'),
-    'eval'                      => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'clr'),
+    'eval'                      => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
     'sql'                       => "int(10) unsigned NOT NULL default '0'"
+);
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['nc_flatten_pattern'] = array
+(
+    'label'                     => &$GLOBALS['TL_LANG']['tl_form']['nc_flatten_pattern'],
+    'exclude'                   => true,
+    'inputType'                 => 'text',
+    'eval'                      => array('doNotTrim'=>true),
+    'sql'                       => "varchar(255) NOT NULL default ''"
 );

--- a/languages/de/tl_form.php
+++ b/languages/de/tl_form.php
@@ -11,6 +11,7 @@
  * last-updated: 2014-07-17T14:48:39+02:00
  */
 
-$GLOBALS['TL_LANG']['tl_form']['nc_notification']['0'] = 'Benachrichtigung';
-$GLOBALS['TL_LANG']['tl_form']['nc_notification']['1'] = 'Bitte wählen Sie eine Benachrichtigung aus.';
-
+$GLOBALS['TL_LANG']['tl_form']['nc_notification']['0']    = 'Benachrichtigung';
+$GLOBALS['TL_LANG']['tl_form']['nc_notification']['1']    = 'Bitte wählen Sie eine Benachrichtigung aus.';
+$GLOBALS['TL_LANG']['tl_form']['nc_flatten_pattern']['0'] = 'Trennzeichen einer Auflistung';
+$GLOBALS['TL_LANG']['tl_form']['nc_flatten_pattern']['1'] = 'Sie können das Muster der Auflistung von Werten ändern; der Standard ist `, `.';

--- a/languages/en/tl_form.php
+++ b/languages/en/tl_form.php
@@ -3,8 +3,9 @@
 /**
  * notification_center extension for Contao Open Source CMS
  *
- * @copyright  Copyright (c) 2008-2015, terminal42
+ * @copyright  Copyright (c) 2008-2016, terminal42
  * @author     terminal42 gmbh <info@terminal42.ch>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
  * @license    LGPL
  */
 
@@ -12,3 +13,4 @@
  * Fields
  */
 $GLOBALS['TL_LANG']['tl_form']['nc_notification']     = array('Notification', 'Please select a notification.');
+$GLOBALS['TL_LANG']['tl_form']['nc_flatten_pattern']  = array('Separating pattern', 'You can override the separating pattern; standard pattern is `, `.');


### PR DESCRIPTION
add pattern parameter field at form definition

depended on https://github.com/codefog/contao-haste/pull/90

you can override the pattern with your own character e.g. `;` or `|` 
... or clean the space from `value1,  value2` to `value1,value2`
