### PR TITLE
Comply with Contao's new opt-in service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
       "contao/newsletter-bundle": "Send notifications using the newsletter bundle of Contao"
     },
     "conflict": {
+      "contao/core-bundle": "4.5.0",
       "contao/newsletter-bundle": "<3.5 || >= 5.0"
     },
     "extra":{

--- a/modules/ModulePasswordNotificationCenter.php
+++ b/modules/ModulePasswordNotificationCenter.php
@@ -48,15 +48,21 @@ class ModulePasswordNotificationCenter extends \ModulePassword
 
 		$token = md5(uniqid(mt_rand(), true));
 		$contaoVersion = VERSION.'.'.BUILD;
-		if (version_compare($contaoVersion, '4.5.4', '>=')
-			|| (version_compare($contaoVersion, '4.5.0', '<') && version_compare($contaoVersion, '4.4.12', '>='))) {
-			$token = 'PW'.substr($token, 2);
+		if (version_compare($contaoVersion, '4.7.0', '>=')) {
+			/** @var \Contao\CoreBundle\OptIn\OptIn $optIn */
+			$optIn = System::getContainer()->get('contao.opt-in');
+			$optInToken = $optIn->create('pw-', $objMember->email, array('tl_member'=>array($objMember->id)));
+			$token = $optInToken->getIdentifier();
+		} elseif (version_compare($contaoVersion, '4.4.12', '>=')) {
+			$token = 'PW' . substr($token, 2);
 		}
 
-		// Store the token
-		$objMember = \MemberModel::findByPk($objMember->id);
-		$objMember->activation = $token;
-		$objMember->save();
+		if (!version_compare($contaoVersion, '4.7.0', '>=')) {
+			// Store the token
+			$objMember = \MemberModel::findByPk($objMember->id);
+			$objMember->activation = $token;
+			$objMember->save();
+		}
 
 		$arrTokens = array();
 


### PR DESCRIPTION
This PR restores compatibility with Contao 4.7, i.e. by following contao/contao#196.

Therefore, I adapted the way of how the token is generated.

I added `contao/core-bundle:4.5.0` as a conflict, because the way the token is generated differs again (see https://github.com/terminal42/contao-notification_center/pull/144#issuecomment-368640953).