### PR TITLE
Add InsertTag parsing to attachment tokens

### DIFF
--- a/library/NotificationCenter/Util/StringUtil.php
+++ b/library/NotificationCenter/Util/StringUtil.php
@@ -73,11 +73,7 @@ class StringUtil
         }
 
         foreach (trimsplit(',', $strAttachmentTokens) as $strToken) {
-            if (version_compare(VERSION . '.' . BUILD, '3.5.1', '<')) {
-                $strParsedToken = \String::parseSimpleTokens($strToken, $arrTokens);
-            } else {
-                $strParsedToken = \StringUtil::parseSimpleTokens($strToken, $arrTokens);
-            }
+            $strParsedToken = \Haste\Util\StringUtil::recursiveReplaceTokensAndTags($strToken, $arrTokens);
 
             foreach (trimsplit(',', $strParsedToken) as $strFile) {
                 $strFileFull = TL_ROOT . '/' . $strFile;


### PR DESCRIPTION
Instead of just parsing simple tokens, InsertTags and simple tokens will be parsed recursively, just as in sender address, sender name et al.

Resolves #181 