### PR TITLE
Fix namespace in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $GLOBALS['NOTIFICATION_CENTER']['NOTIFICATION_TYPE']['isotope'] = array
 Extension developers most likely want to send a single notification identified by ID,:
 
 ```php
-$objNotification = NotificationCenter\Model\Notification::findByPk($intNotificationId);
+$objNotification = \NotificationCenter\Model\Notification::findByPk($intNotificationId);
 if (null !== $objNotification) {
     $objNotification->send($arrTokens, $strLanguage); // Language is optional
 }
@@ -50,7 +50,7 @@ If you want to send all notifications of a certain type, you can send it like th
 
 ```php
 $strType = 'iso_order_status_change';
-$objNotificationCollection = NotificationCenter\Model\Notification::findByType($strType);
+$objNotificationCollection = \NotificationCenter\Model\Notification::findByType($strType);
 if (null !== $objNotificationCollection) {
     while ($objNotificationCollection->next()) {
         $objNotification = $objNotificationCollection->current();


### PR DESCRIPTION
The namespaces in the example code are relative, which led to confusion among a developer in Slack. I made them absolute so it is clear which class has to be used and it works, when copying and pasting the example code.