### PR TITLE
Fix class for tl_form.nc_notification

### DIFF
--- a/dca/tl_form.php
+++ b/dca/tl_form.php
@@ -22,6 +22,8 @@ $GLOBALS['TL_DCA']['tl_form']['fields']['nc_notification'] = array
     'exclude'                   => true,
     'inputType'                 => 'select',
     'options_callback'          => array('NotificationCenter\tl_form', 'getNotificationChoices'),
-    'eval'                      => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'clr'),
+    'eval'                      => array('includeBlankOption'=>true, 'chosen'=>true, 'tl_class'=>'clr w50'),
     'sql'                       => "int(10) unsigned NOT NULL default '0'"
 );
+
+$GLOBALS['TL_DCA']['tl_form']['fields']['sendViaEmail']['eval']['tl_class'] = 'clr w50';


### PR DESCRIPTION
The `tl_form.nc_notification` field is currently displayed with a full width in the back end (contrary to `tl_module.nc_notification`, which has `w50` applied already), which looks a bit off. This PR fixes that (it also adds `clr` to the following `sendViaEmail` field).