### PR TITLE
Fix language switch in message

### DIFF
--- a/library/NotificationCenter/Model/Message.php
+++ b/library/NotificationCenter/Model/Message.php
@@ -76,7 +76,7 @@ class Message extends \Model
         if (null !== ($objLanguage = Language::findByMessageAndLanguageOrFallback($this, $cpLanguage))) {
              // Switch to the language of the notification
             $this->saveCurrentFrameworkLanguage();
-            $this->setFrameworkLanguage($objLanguage->language, str_replace('-', '_', $objLanguage->language));
+            $this->setFrameworkLanguage($objLanguage->language, $objLanguage->language);
         }
 
         $objGateway = $objGatewayModel->getGateway();
@@ -159,6 +159,9 @@ class Message extends \Model
         if (!$language || !$locale) {
             return;
         }
+
+        $language = str_replace('_', '-', $language);
+        $locale = str_replace('-', '_', $locale);
 
         $GLOBALS['TL_LANGUAGE'] = $language;
         \Contao\System::getContainer()->get('translator')->setLocale($locale);

--- a/library/NotificationCenter/Model/Message.php
+++ b/library/NotificationCenter/Model/Message.php
@@ -147,6 +147,7 @@ class Message extends \Model
 
     private function saveCurrentFrameworkLanguage()
     {
+        $this->currentLanguage = $GLOBALS['TL_LANGUAGE'];
         $this->currentLocale = \Contao\System::getContainer()->get('translator')->getLocale();
     }
 


### PR DESCRIPTION
Since https://github.com/terminal42/contao-notification_center/commit/fd07e5a84da3f728cee423fb68faaa48360ecdce the current framework language is no longer saved correctly with `saveCurrentFrameworkLanguage` in the `Message` class.

Unfortunately the format of the framework language from the message was not correctly in the past. To insure the correct format of language + locale I added the `str_replace` to  the `setFramework` method. 
If there is only support for contao 4.13+ this could be replaced by using `Contao\CoreBundle\Util\LocaleUtil`