### PR TITLE
Change language SQL VARCHAR to 11 characters

### DIFF
--- a/dca/tl_nc_language.php
+++ b/dca/tl_nc_language.php
@@ -143,7 +143,7 @@ $GLOBALS['TL_DCA']['tl_nc_language'] = array
             'inputType'               => 'select',
             'options'                 => \System::getLanguages(),
             'eval'                    => array('mandatory'=>true, 'chosen'=>true, 'tl_class'=>'w50'),
-            'sql'                     => "varchar(5) NOT NULL default ''",
+            'sql'                     => "varchar(11) NOT NULL default ''",
             'save_callback' => array
             (
                 array('NotificationCenter\tl_nc_language', 'validateLanguageField')


### PR DESCRIPTION
\System::getLanguages(); returns longer Locales so that for example Chinese Simplified can't be stored anymore.
Former zh_CN is now zh_Hans or a longer version of that.

Currently, not all languages can be saved.

The longest value is "vai_Vaii_LR" with 11 Characters for "Vai (Vai, Liberia) - ꕙꔤ (Vaii, ꕞꔤꔫꕩ)".