### PR TITLE
Add support for form errors

### DIFF
--- a/classes/tl_form.php
+++ b/classes/tl_form.php
@@ -47,13 +47,15 @@ class tl_form extends \Backend
      * @param array $arrForm
      * @param array $arrFiles
      * @param array $arrLabels
+     * @param \Contao\Form $form
      */
-    public function sendFormNotification($arrData, $arrForm, $arrFiles, $arrLabels)
+    public function sendFormNotification($arrData, $arrForm, $arrFiles, $arrLabels, $form)
     {
         if (!$arrForm['nc_notification'] || ($objNotification = Model\Notification::findByPk($arrForm['nc_notification'])) === null) {
             return;
         }
 
+        $objNotification->setForm($form);
         $objNotification->send(
             $this->generateTokens(
                 (array) $arrData,

--- a/library/NotificationCenter/Gateway/Email.php
+++ b/library/NotificationCenter/Gateway/Email.php
@@ -109,6 +109,7 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
             try {
                 $objEmail->replyTo($strReplyTo);
             } catch (\Exception $e) {
+                $this->objModel->addFormError();
                 \System::log(sprintf('Could not set reply-to address "%s" for message ID %s: %s', $strReplyTo, $objDraft->getMessage()->id, $e->getMessage()), __METHOD__, TL_ERROR);
                 return false;
             }
@@ -160,6 +161,7 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
         try {
             return $objEmail->sendTo($objDraft->getRecipientEmails());
         } catch (\Exception $e) {
+            $this->objModel->addFormError();
             \System::log(sprintf('Could not send email to "%s" for message ID %s: %s', implode(', ', $objDraft->getRecipientEmails()), $objDraft->getMessage()->id, $e->getMessage()), __METHOD__, TL_ERROR);
         }
 
@@ -185,6 +187,7 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
         // return false if no language found for BC
         if ($objDraft === null) {
 
+            $this->objModel->addFormError();
             \System::log(sprintf('Could not create draft message for e-mail (Message ID: %s)', $objMessage->id), __METHOD__, TL_ERROR);
 
             return false;

--- a/library/NotificationCenter/Gateway/File.php
+++ b/library/NotificationCenter/Gateway/File.php
@@ -69,6 +69,7 @@ class File extends Base implements GatewayInterface
         try {
             return $this->save($strFileName, $strContent, (string) $objLanguage->file_storage_mode);
         } catch (\Exception $e) {
+            $this->objModel->addFormError();
             \System::log('Notification Center gateway error: ' . $e->getMessage(), __METHOD__, TL_ERROR);
 
             return false;

--- a/library/NotificationCenter/Gateway/Postmark.php
+++ b/library/NotificationCenter/Gateway/Postmark.php
@@ -81,6 +81,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
         $arrBcc = $objDraft->getBccRecipientEmails();
 
         if (count(array_merge($arrTo, $arrCc, $arrBcc)) >= 20) {
+            $this->objModel->addFormError();
             \System::log(
                 sprintf('The Postmark gateway does not support sending to more than 20 recipients (CC and BCC included) for message ID "%s".',
                     $objMessage->id
@@ -136,6 +137,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
         }
 
         if ($objRequest->hasError()) {
+            $this->objModel->addFormError();
             \System::log(
                 sprintf('Error sending the Postmark request for message ID "%s". HTTP Response status code: %s. JSON data sent: %s',
                     $objMessage->id,

--- a/library/NotificationCenter/MessageDraft/MessageDraftInterface.php
+++ b/library/NotificationCenter/MessageDraft/MessageDraftInterface.php
@@ -20,7 +20,7 @@ interface MessageDraftInterface
 
     /**
      * Returns the message model for that message draft
-     * @return \NotificationCenter\MessageDraft\Message
+     * @return \NotificationCenter\Model\Message
      */
     public function getMessage();
 

--- a/library/NotificationCenter/Model/FormErrorTrait.php
+++ b/library/NotificationCenter/Model/FormErrorTrait.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * notification_center extension for Contao Open Source CMS
+ *
+ * @copyright  Copyright (c) 2008-2015, terminal42
+ * @author     terminal42 gmbh <info@terminal42.ch>
+ * @license    LGPL
+ */
+
+namespace NotificationCenter\Model;
+
+use Contao\Form;
+
+trait FormErrorTrait
+{
+    /**
+     * @var Form|null
+     */
+    protected $form = null;
+
+    /**
+     * @param Form|null $form
+     *
+     * @return self
+     */
+    public function setForm($form)
+    {
+        $this->form = $form;
+
+        return $this;
+    }
+
+    /**
+     * @return Form|null
+     */
+    public function getForm()
+    {
+        return $this->form;
+    }
+
+    /**
+     * @param string $error
+     *
+     * @return self
+     */
+    public function addFormError($error = '')
+    {
+        if (null === $this->form || !method_exists($this->form, 'addError')) {
+            return $this;
+        }
+
+        if (empty($error)) {
+            $error = $GLOBALS['TL_LANG']['ERR']['general'];
+        }
+
+        $this->form->addError($error);
+
+        return $this;
+    }
+}

--- a/library/NotificationCenter/Model/Gateway.php
+++ b/library/NotificationCenter/Model/Gateway.php
@@ -15,6 +15,7 @@ use NotificationCenter\Gateway\GatewayInterface;
 
 class Gateway extends Model
 {
+    use FormErrorTrait;
 
     /**
      * Name of the current table
@@ -56,6 +57,7 @@ class Gateway extends Model
                 $this->objGateway = $objGateway;
 
             } catch (\Exception $e) {
+                $this->addFormError();
                 \System::log(sprintf('There was a general error building the gateway: "%s".', $e->getMessage()), __METHOD__, TL_ERROR);
 
                 return null;

--- a/library/NotificationCenter/Model/Message.php
+++ b/library/NotificationCenter/Model/Message.php
@@ -14,6 +14,7 @@ use NotificationCenter\Gateway\Email;
 
 class Message extends \Model
 {
+    use FormErrorTrait;
 
     /**
      * Name of the current table

--- a/library/NotificationCenter/Model/Notification.php
+++ b/library/NotificationCenter/Model/Notification.php
@@ -14,6 +14,7 @@ use Contao\Model;
 
 class Notification extends Model
 {
+    use FormErrorTrait;
 
     /**
      * Name of the current table
@@ -49,6 +50,7 @@ class Notification extends Model
         $arrResult = array();
 
         foreach ($objMessages as $objMessage) {
+            $objMessage->setForm($this->form);
             $arrResult[$objMessage->id] = $objMessage->send($arrTokens, $strLanguage);
         }
 
@@ -104,6 +106,7 @@ class Notification extends Model
 
                 $tokens['template_'.substr($name, 13)] = $template->parse();
             } catch (\Exception $e) {
+                $this->addFormError();
                 \System::log('Could not generate token template "'.$name.'"', __METHOD__, TL_ERROR);
             }
         }

--- a/library/NotificationCenter/Queue/QueueManager.php
+++ b/library/NotificationCenter/Queue/QueueManager.php
@@ -169,6 +169,7 @@ class QueueManager implements QueueManagerInterface
                 (new Filesystem())->copy($originalPath, $clonePath);
                 $attachments[$index] = $clonePath;
             } catch (\Exception $exception) {
+                $message->addFormError();
                 // noop
             }
         }
@@ -188,4 +189,4 @@ class QueueManager implements QueueManagerInterface
     {
         return 'var/notification_center/' . $messageId;
     }
-} 
+}


### PR DESCRIPTION
This is a draft to solve #258 
It depends on https://github.com/contao/contao/pull/4898

At the moment I added form errors to the exception catches. Maybe we could add some more errors.
Currently I did not add any special error messages, it will always be `ERR.general` but could be overriden.