### PR TITLE
Fix newsletter compatibility

### DIFF
--- a/config/autoload.ini
+++ b/config/autoload.ini
@@ -3,6 +3,7 @@
 ;;
 requires[] = "core"
 requires[] = "dcawizard"
+requires[] = "*newsletter"
 
 ;;
 ; Configure what you want the autoload creator to register


### PR DESCRIPTION
Fixes https://github.com/terminal42/contao-notification_center/issues/288

The problem is the loading order. The `notification_center` module might get loaded before the `ContaoNewsletterBundle`. This PR fixes that.