### PR TITLE
Send error at log if recipient email empty

### DIFF
--- a/library/NotificationCenter/Gateway/Email.php
+++ b/library/NotificationCenter/Gateway/Email.php
@@ -157,8 +157,12 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
             $objEmail->sendBcc($arrBcc);
         }
 
+        if (empty($recipientEmails = $objDraft->getRecipientEmails())) {
+            \System::log(sprintf('Recipient email is empty - could not send email to for message ID %s.', $objDraft->getMessage()->id), __METHOD__, TL_ERROR);
+        }
+
         try {
-            return $objEmail->sendTo($objDraft->getRecipientEmails());
+            return $objEmail->sendTo($recipientEmails);
         } catch (\Exception $e) {
             \System::log(sprintf('Could not send email to "%s" for message ID %s: %s', implode(', ', $objDraft->getRecipientEmails()), $objDraft->getMessage()->id, $e->getMessage()), __METHOD__, TL_ERROR);
         }


### PR DESCRIPTION
Currently there is no info why an email is not sent because the recipient address field is empty - e.g. when it is filled by a simple token.