### PR TITLE
Split friendly admin email

### DIFF
--- a/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
+++ b/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
@@ -288,11 +288,11 @@ class EmailMessageDraft implements MessageDraftInterface
 
     private function getAdminEmail(): string
     {
-        return \Contao\StringUtil::splitFriendlyEmail(Config::get('adminEmail'))[1];
+        return $GLOBALS['TL_ADMIN_EMAIL'] ?? \Contao\StringUtil::splitFriendlyEmail(Config::get('adminEmail'))[1];
     }
 
     private function getAdminName(): string
     {
-        return \Contao\StringUtil::splitFriendlyEmail(Config::get('adminEmail'))[0];
+        return $GLOBALS['TL_ADMIN_NAME'] ?? \Contao\StringUtil::splitFriendlyEmail(Config::get('adminEmail'))[0];
     }
 }

--- a/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
+++ b/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
@@ -14,7 +14,6 @@ namespace NotificationCenter\MessageDraft;
 use Codefog\HasteBundle\StringParser;
 use Contao\Config;
 use Contao\File;
-use Contao\StringUtil as ContaoStringUtil;
 use Contao\System;
 use NotificationCenter\Model\Language;
 use NotificationCenter\Model\Message;
@@ -71,11 +70,7 @@ class EmailMessageDraft implements MessageDraftInterface
      */
     public function getSenderEmail()
     {
-        if (!isset($GLOBALS['TL_ADMIN_EMAIL'])) {
-            [$GLOBALS['TL_ADMIN_NAME'], $GLOBALS['TL_ADMIN_EMAIL']] = ContaoStringUtil::splitFriendlyEmail(Config::get('adminEmail'));
-        }
-
-        $strSenderAddress = $this->objLanguage->email_sender_address ?: $GLOBALS['TL_ADMIN_EMAIL'];
+        $strSenderAddress = $this->objLanguage->email_sender_address ?: $this->getAdminEmail();
 
         return System::getContainer()->get(StringParser::class)->recursiveReplaceTokensAndTags($strSenderAddress, $this->arrTokens, StringUtil::NO_TAGS | StringUtil::NO_BREAKS);
     }
@@ -86,11 +81,7 @@ class EmailMessageDraft implements MessageDraftInterface
      */
     public function getSenderName()
     {
-        if (!isset($GLOBALS['TL_ADMIN_EMAIL'])) {
-            [$GLOBALS['TL_ADMIN_NAME'], $GLOBALS['TL_ADMIN_EMAIL']] = ContaoStringUtil::splitFriendlyEmail(Config::get('adminEmail'));
-        }
-
-        $strSenderName = $this->objLanguage->email_sender_name ?: $GLOBALS['TL_ADMIN_NAME'];
+        $strSenderName = $this->objLanguage->email_sender_name ?: $this->getAdminName();
 
         return System::getContainer()->get(StringParser::class)->recursiveReplaceTokensAndTags($strSenderName, $this->arrTokens, StringUtil::NO_TAGS | StringUtil::NO_BREAKS);
     }
@@ -293,5 +284,15 @@ class EmailMessageDraft implements MessageDraftInterface
     public function getLanguage()
     {
         return $this->objLanguage->language;
+    }
+
+    private function getAdminEmail(): string
+    {
+        return \Contao\StringUtil::splitFriendlyEmail(Config::get('adminEmail'))[1];
+    }
+
+    private function getAdminName(): string
+    {
+        return \Contao\StringUtil::splitFriendlyEmail(Config::get('adminEmail'))[0];
     }
 }

--- a/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
+++ b/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
@@ -14,6 +14,7 @@ namespace NotificationCenter\MessageDraft;
 use Codefog\HasteBundle\StringParser;
 use Contao\Config;
 use Contao\File;
+use Contao\StringUtil as ContaoStringUtil;
 use Contao\System;
 use NotificationCenter\Model\Language;
 use NotificationCenter\Model\Message;
@@ -70,7 +71,11 @@ class EmailMessageDraft implements MessageDraftInterface
      */
     public function getSenderEmail()
     {
-        $strSenderAddress = $this->objLanguage->email_sender_address ?: ($GLOBALS['TL_ADMIN_EMAIL'] ?? Config::get('adminEmail'));
+        if (!isset($GLOBALS['TL_ADMIN_EMAIL'])) {
+            [$GLOBALS['TL_ADMIN_NAME'], $GLOBALS['TL_ADMIN_EMAIL']] = ContaoStringUtil::splitFriendlyEmail(Config::get('adminEmail'));
+        }
+
+        $strSenderAddress = $this->objLanguage->email_sender_address ?: $GLOBALS['TL_ADMIN_EMAIL'];
 
         return System::getContainer()->get(StringParser::class)->recursiveReplaceTokensAndTags($strSenderAddress, $this->arrTokens, StringUtil::NO_TAGS | StringUtil::NO_BREAKS);
     }
@@ -81,7 +86,11 @@ class EmailMessageDraft implements MessageDraftInterface
      */
     public function getSenderName()
     {
-        $strSenderName = $this->objLanguage->email_sender_name ?: ($GLOBALS['TL_ADMIN_NAME'] ?? '');
+        if (!isset($GLOBALS['TL_ADMIN_EMAIL'])) {
+            [$GLOBALS['TL_ADMIN_NAME'], $GLOBALS['TL_ADMIN_EMAIL']] = ContaoStringUtil::splitFriendlyEmail(Config::get('adminEmail'));
+        }
+
+        $strSenderName = $this->objLanguage->email_sender_name ?: $GLOBALS['TL_ADMIN_NAME'];
 
         return System::getContainer()->get(StringParser::class)->recursiveReplaceTokensAndTags($strSenderName, $this->arrTokens, StringUtil::NO_TAGS | StringUtil::NO_BREAKS);
     }


### PR DESCRIPTION
If a notification is sent in a context without a request, or without `FrontendIndex` being rendered, `$GLOBALS['TL_ADMIN_EMAIL']` will be empty. In such a case the notification center currently falls back to `Config::get('adminEmail')` - however, this config might contain 'friendly' email addresses such as

```
Lorem Ipsum <foobar@example.com>
```
```
Lorem Ipsum [foobar@example.com]
```

This would then be used directly for `$this->objLanguage->email_sender_address`, resulting in an invalid sender address.

This PR fixes that by splitting the friendly email address.