### PR TITLE
Fix deprecated Contao namespaces and add phpstan (dev-dependency)

### DIFF
--- a/classes/tl_form.php
+++ b/classes/tl_form.php
@@ -12,10 +12,12 @@ namespace NotificationCenter;
 
 use Codefog\HasteBundle\StringParser;
 use Contao\ArrayUtil;
+use Contao\Backend;
+use Contao\Database;
 use Contao\System;
 use NotificationCenter\Util\Form;
 
-class tl_form extends \Backend
+class tl_form extends Backend
 {
 
     public function __construct()
@@ -31,7 +33,7 @@ class tl_form extends \Backend
     public function getNotificationChoices()
     {
         $arrChoices = array();
-        $objNotifications = \Database::getInstance()->execute("SELECT id,title FROM tl_nc_notification WHERE type='core_form' ORDER BY title");
+        $objNotifications = Database::getInstance()->execute("SELECT id,title FROM tl_nc_notification WHERE type='core_form' ORDER BY title");
 
         while ($objNotifications->next()) {
             $arrChoices[$objNotifications->id] = $objNotifications->title;

--- a/classes/tl_member.php
+++ b/classes/tl_member.php
@@ -10,6 +10,8 @@
 
 namespace NotificationCenter;
 
+use Contao\FrontendUser;
+
 class tl_member
 {
     /**
@@ -19,7 +21,7 @@ class tl_member
     {
         if ('FE' === TL_MODE && true === FE_USER_LOGGED_IN)
         {
-            $_SESSION['PERSONAL_DATA'] = \FrontendUser::getInstance()->getData();
+            $_SESSION['PERSONAL_DATA'] = FrontendUser::getInstance()->getData();
         }
     }
 }

--- a/classes/tl_module.php
+++ b/classes/tl_module.php
@@ -10,16 +10,20 @@
 
 namespace NotificationCenter;
 
-class tl_module extends \Backend
+use Contao\Backend;
+use Contao\Database;
+use Contao\DataContainer;
+
+class tl_module extends Backend
 {
     /**
      * Get notification choices
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return array
      */
-    public function getNotificationChoices(\DataContainer $dc)
+    public function getNotificationChoices(DataContainer $dc)
     {
         $strWhere = '';
         $arrValues = array();
@@ -31,7 +35,7 @@ class tl_module extends \Backend
         }
 
         $arrChoices = array();
-        $objNotifications = \Database::getInstance()->prepare('SELECT id,title FROM tl_nc_notification' . $strWhere . ' ORDER BY title')
+        $objNotifications = Database::getInstance()->prepare('SELECT id,title FROM tl_nc_notification' . $strWhere . ' ORDER BY title')
                                            ->execute($arrValues);
 
         while ($objNotifications->next()) {

--- a/classes/tl_nc_gateway.php
+++ b/classes/tl_nc_gateway.php
@@ -10,18 +10,22 @@
 
 namespace NotificationCenter;
 
+use Contao\Backend;
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
+use Contao\DataContainer;
+use Contao\Message;
+use Contao\System;
 use NotificationCenter\Gateway\LabelCallbackInterface;
 use NotificationCenter\Model\Gateway;
 
-class tl_nc_gateway extends \Backend
+class tl_nc_gateway extends Backend
 {
     /**
      * Loads the language file tl_settings
      */
     public function loadSettingsLanguageFile()
     {
-        \System::loadLanguageFile('tl_settings');
+        System::loadLanguageFile('tl_settings');
     }
 
     public function loadPalette($dc)
@@ -69,9 +73,9 @@ class tl_nc_gateway extends \Backend
     /**
      * Check the FTP connection
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      */
-    public function checkFileServerConnection(\DataContainer $dc)
+    public function checkFileServerConnection(DataContainer $dc)
     {
         if ('ftp' !== $dc->activeRecord->type || 'ftp' !== $dc->activeRecord->file_connection) {
             return;
@@ -79,7 +83,7 @@ class tl_nc_gateway extends \Backend
 
         // Try to connect
         if (($ftp = @ftp_connect($dc->activeRecord->file_host, (int) ($dc->activeRecord->file_port ?: 21), 5)) === false) {
-            \Message::addError($GLOBALS['TL_LANG']['tl_nc_gateway']['ftp_error_connect']);
+            Message::addError($GLOBALS['TL_LANG']['tl_nc_gateway']['ftp_error_connect']);
 
             return;
         }
@@ -87,12 +91,12 @@ class tl_nc_gateway extends \Backend
         // Try to login
         if (false === @ftp_login($ftp, $dc->activeRecord->file_username, $dc->activeRecord->file_password)) {
             @ftp_close($ftp);
-            \Message::addError($GLOBALS['TL_LANG']['tl_nc_gateway']['ftp_error_login']);
+            Message::addError($GLOBALS['TL_LANG']['tl_nc_gateway']['ftp_error_login']);
 
             return;
         }
 
-        \Message::addConfirmation($GLOBALS['TL_LANG']['tl_nc_gateway']['ftp_confirm']);
+        Message::addConfirmation($GLOBALS['TL_LANG']['tl_nc_gateway']['ftp_confirm']);
     }
 
     /**
@@ -100,12 +104,12 @@ class tl_nc_gateway extends \Backend
      *
      * @param array          $row
      * @param string         $label
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      * @param array          $args
      *
      * @return string
      */
-    public function executeLabelCallback($row, $label, \DataContainer $dc, $args)
+    public function executeLabelCallback($row, $label, DataContainer $dc, $args)
     {
         $model = Gateway::findByPk($row['id']);
         $gateway = $model->getGateway();
@@ -121,11 +125,11 @@ class tl_nc_gateway extends \Backend
     /**
      * Gets the cron job explanation
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return string
      */
-    public function queueCronjobExplanation(\DataContainer $dc)
+    public function queueCronjobExplanation(DataContainer $dc)
     {
         return sprintf('<div style="color: #4b85ba;
             background: #eff5fa;

--- a/classes/tl_nc_language.php
+++ b/classes/tl_nc_language.php
@@ -10,20 +10,26 @@
 
 namespace NotificationCenter;
 
+use Contao\Backend;
+use Contao\Database;
+use Contao\DataContainer;
+use Contao\Input;
+use Contao\StringUtil;
+use Contao\Validator;
 use NotificationCenter\Model\Gateway;
 use NotificationCenter\Model\Language;
 
-class tl_nc_language extends \Backend
+class tl_nc_language extends Backend
 {
 
     /**
      * Modifies the palette for the queue gateway so it takes the one from the target gateway
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      */
-    public function modifyPalette(\DataContainer $dc)
+    public function modifyPalette(DataContainer $dc)
     {
-        if ('edit' !== \Input::get('act')) {
+        if ('edit' !== Input::get('act')) {
             return;
         }
 
@@ -44,12 +50,12 @@ class tl_nc_language extends \Backend
      * @param string         $strTable
      * @param int            $insertID
      * @param array          $arrSet
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      */
     public function insertGatewayType($strTable, $insertID, $arrSet, $dc)
     {
         if ('tl_nc_language' === $strTable) {
-            \Database::getInstance()->prepare("
+            Database::getInstance()->prepare("
                 UPDATE tl_nc_language SET gateway_type=(SELECT type FROM tl_nc_gateway WHERE id=(SELECT gateway FROM tl_nc_message WHERE id=?)) WHERE id=?
             ")->execute($arrSet['pid'], $insertID);
         }
@@ -60,12 +66,12 @@ class tl_nc_language extends \Backend
      * Check if the language field is unique per message
      *
      * @param mixed          $varValue
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return mixed
      * @throws \Exception
      */
-    public function validateLanguageField($varValue, \DataContainer $dc)
+    public function validateLanguageField($varValue, DataContainer $dc)
     {
         $objLanguages = $this->Database->prepare("SELECT id FROM tl_nc_language WHERE language=? AND pid=? AND id!=?")
             ->limit(1)
@@ -84,12 +90,12 @@ class tl_nc_language extends \Backend
      * Make sure the fallback field is a fallback per message
      *
      * @param mixed          $varValue
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return mixed
      * @throws \Exception
      */
-    public function validateFallbackField($varValue, \DataContainer $dc)
+    public function validateFallbackField($varValue, DataContainer $dc)
     {
         if ($varValue) {
             $objLanguages = $this->Database->prepare("SELECT id FROM tl_nc_language WHERE fallback=1 AND pid=? AND id!=?")
@@ -110,15 +116,15 @@ class tl_nc_language extends \Backend
      * Validate e-mail addresses in the comma separated list
      *
      * @param mixed          $varValue
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return mixed
      * @throws \Exception
      */
-    public function validateEmailList($varValue, \DataContainer $dc)
+    public function validateEmailList($varValue, DataContainer $dc)
     {
         if ($varValue != '') {
-            $chunks = trimsplit(',', $varValue);
+            $chunks = StringUtil::trimsplit(',', $varValue);
 
             foreach ($chunks as $chunk) {
 
@@ -127,7 +133,7 @@ class tl_nc_language extends \Backend
                     continue;
                 }
 
-                if (!\Validator::isEmail($chunk)) {
+                if (!Validator::isEmail($chunk)) {
                     throw new \Exception($GLOBALS['TL_LANG']['ERR']['emails']);
                 }
             }

--- a/classes/tl_nc_message.php
+++ b/classes/tl_nc_message.php
@@ -67,7 +67,7 @@ class tl_nc_message extends Backend
     public function listRows($arrRow)
     {
         if (0 === count($this->arrTranslations)) {
-            $this->arrTranslations = System::getLanguages();
+            $this->arrTranslations = System::getContainer()->get('contao.intl.locales')->getLocales(null, true);;
         }
         if (0 === count($this->arrGateways)) {
             $objGateways = Database::getInstance()->execute('SELECT id,title FROM tl_nc_gateway');

--- a/classes/tl_nc_notification.php
+++ b/classes/tl_nc_notification.php
@@ -10,7 +10,10 @@
 
 namespace NotificationCenter;
 
-class tl_nc_notification extends \Backend
+use Contao\Backend;
+use Contao\DataContainer;
+
+class tl_nc_notification extends Backend
 {
     /**
      * Get all registered notification types
@@ -39,7 +42,7 @@ class tl_nc_notification extends \Backend
      * @param int            $intMode
      * @param string         $strField
      * @param array          $arrRow
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return string
      */

--- a/classes/tl_nc_queue.php
+++ b/classes/tl_nc_queue.php
@@ -10,17 +10,24 @@
 
 namespace NotificationCenter;
 
+use Contao\Backend;
+use Contao\Controller;
+use Contao\DataContainer;
+use Contao\Date;
+use Contao\Environment;
+use Contao\Image;
+use Contao\StringUtil;
 use NotificationCenter\Model\QueuedMessage;
 use NotificationCenter\Queue\QueueManager;
 
-class tl_nc_queue extends \Backend
+class tl_nc_queue extends Backend
 {
     /**
      * On delete callback.
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      */
-    public function onDeleteCallback(\DataContainer $dc)
+    public function onDeleteCallback(DataContainer $dc)
     {
         $queueManager = new $GLOBALS['NOTIFICATION_CENTER']['QUEUE_MANAGER']();
 
@@ -34,14 +41,14 @@ class tl_nc_queue extends \Backend
      *
      * @param array          $arrRow
      * @param string         $label
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return string
      */
     public function listRows($arrRow, $label, $dc)
     {
         $strBuffer = '<span style="color:#b3b3b3;padding-right:3px">[%s]</span>';
-        $arrValues = array(\Date::parse(\Date::getNumericDatimFormat(), $arrRow['dateAdded']));
+        $arrValues = array(Date::parse(Date::getNumericDatimFormat(), $arrRow['dateAdded']));
 
         $objQueuedMessage = QueuedMessage::findByPk($arrRow['id']);
 
@@ -74,13 +81,13 @@ class tl_nc_queue extends \Backend
     /**
      * Re-queue a queued message
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      */
-    public function reQueue(\DataContainer $dc)
+    public function reQueue(DataContainer $dc)
     {
         $objQueuedMsg = QueuedMessage::findByPk($dc->id);
         $objQueuedMsg->reQueue();
-        \Controller::redirect(str_replace('&key=re-queue', '', \Environment::get('request')));
+        Controller::redirect(str_replace('&key=re-queue', '', Environment::get('request')));
     }
 
     /**
@@ -98,7 +105,7 @@ class tl_nc_queue extends \Backend
     public function reQueueButton($row, $href, $label, $title, $icon, $attributes)
     {
         $objMessage = QueuedMessage::findByPk($row['id']);
-        return ($objMessage->getStatus() === 'error') ? '<a href="' . \Backend::addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . specialchars($title) . '"' . $attributes . '>' . \Image::getHtml($icon, $label) . '</a> ' : '';
+        return ($objMessage->getStatus() === 'error') ? '<a href="' . Backend::addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : '';
     }
 
     /**
@@ -116,6 +123,6 @@ class tl_nc_queue extends \Backend
     public function deleteButton($row, $href, $label, $title, $icon, $attributes)
     {
         $objMessage = QueuedMessage::findByPk($row['id']);
-        return ($objMessage->getStatus() !== 'sent') ? '<a href="' . \Backend::addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . specialchars($title) . '"' . $attributes . '>' . \Image::getHtml($icon, $label) . '</a> ' : '';
+        return ($objMessage->getStatus() !== 'sent') ? '<a href="' . Backend::addToUrl($href . '&amp;id=' . $row['id']) . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . Image::getHtml($icon, $label) . '</a> ' : '';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "terminal42/dcawizard": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "contao/newsletter-bundle": "^4.13 || ^5.0"
+        "contao/newsletter-bundle": "^4.13 || ^5.0",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-0": {

--- a/config/runonce.php
+++ b/config/runonce.php
@@ -8,7 +8,9 @@
  * @license    LGPL
  */
 
-if (\Database::getInstance()->tableExists('tl_nc_language') && \Database::getInstance()->fieldExists('file_override', 'tl_nc_language')) {
-    \Database::getInstance()->execute("ALTER TABLE tl_nc_language CHANGE file_override file_storage_mode varchar(8) NOT NULL default ''");
-    \Database::getInstance()->execute("UPDATE tl_nc_language SET file_storage_mode='override' WHERE file_storage_mode!=''");
+use Contao\Database;
+
+if (Database::getInstance()->tableExists('tl_nc_language') && Database::getInstance()->fieldExists('file_override', 'tl_nc_language')) {
+    Database::getInstance()->execute("ALTER TABLE tl_nc_language CHANGE file_override file_storage_mode varchar(8) NOT NULL default ''");
+    Database::getInstance()->execute("UPDATE tl_nc_language SET file_storage_mode='override' WHERE file_storage_mode!=''");
 }

--- a/dca/tl_nc_gateway.php
+++ b/dca/tl_nc_gateway.php
@@ -20,7 +20,7 @@ $GLOBALS['TL_DCA']['tl_nc_gateway'] = array
     // Config
     'config' => array
     (
-        'dataContainer'               => 'Table',
+        'dataContainer'               => \Contao\DC_Table::class,
         'enableVersioning'            => true,
         'onload_callback' => array
         (

--- a/dca/tl_nc_gateway.php
+++ b/dca/tl_nc_gateway.php
@@ -8,6 +8,9 @@
  * @license    LGPL
  */
 
+use Contao\CoreBundle\Mailer\AvailableTransports;
+use Contao\Database;
+
 /**
  * Table tl_nc_gateway
  */
@@ -153,7 +156,7 @@ $GLOBALS['TL_DCA']['tl_nc_gateway'] = array
             'options_callback'        => function() {
                 $options = array();
 
-                $gateways = \Database::getInstance()->prepare('SELECT id,title FROM tl_nc_gateway WHERE type!=?')
+                $gateways = Database::getInstance()->prepare('SELECT id,title FROM tl_nc_gateway WHERE type!=?')
                     ->execute('queue');
 
                 while ($gateways->next()) {
@@ -257,7 +260,7 @@ $GLOBALS['TL_DCA']['tl_nc_gateway'] = array
             'exclude'                 => true,
             'inputType'               => 'select',
             'eval'                    => array('tl_class'=>'w50', 'includeBlankOption'=>true),
-            'options_callback'        => array(\Contao\CoreBundle\Mailer\AvailableTransports::class, 'getTransportOptions'),
+            'options_callback'        => array(AvailableTransports::class, 'getTransportOptions'),
             'sql'                     => "varchar(255) NOT NULL default ''"
         ),
         'file_type' => array

--- a/dca/tl_nc_language.php
+++ b/dca/tl_nc_language.php
@@ -20,7 +20,7 @@ $GLOBALS['TL_DCA']['tl_nc_language'] = array
     'config' => array
     (
         'ptable'                      => 'tl_nc_message',
-        'dataContainer'               => 'Table',
+        'dataContainer'               => \Contao\DC_Table::class,
         'enableVersioning'            => true,
         'oncreate_callback' => array
         (

--- a/dca/tl_nc_message.php
+++ b/dca/tl_nc_message.php
@@ -158,8 +158,8 @@ $GLOBALS['TL_DCA']['tl_nc_message'] = array
             (
                 // Save gateway_type
                 function($varValue, $dc) {
-                    \Database::getInstance()->prepare("UPDATE tl_nc_message SET gateway_type=(SELECT type FROM tl_nc_gateway WHERE id=?) WHERE id=?")->execute($varValue, $dc->id);
-                    \Database::getInstance()->prepare("UPDATE tl_nc_language SET gateway_type=(SELECT type FROM tl_nc_gateway WHERE id=?) WHERE pid=?")->execute($varValue, $dc->id);
+                    \Contao\Database::getInstance()->prepare("UPDATE tl_nc_message SET gateway_type=(SELECT type FROM tl_nc_gateway WHERE id=?) WHERE id=?")->execute($varValue, $dc->id);
+                    \Contao\Database::getInstance()->prepare("UPDATE tl_nc_language SET gateway_type=(SELECT type FROM tl_nc_gateway WHERE id=?) WHERE pid=?")->execute($varValue, $dc->id);
 
                     return $varValue;
                 }

--- a/dca/tl_nc_message.php
+++ b/dca/tl_nc_message.php
@@ -21,7 +21,7 @@ $GLOBALS['TL_DCA']['tl_nc_message'] = array
     (
         'ptable'                      => 'tl_nc_notification',
         'ctable'                      => array('tl_nc_language'),
-        'dataContainer'               => 'Table',
+        'dataContainer'               => \Contao\DC_Table::class,
         'enableVersioning'            => true,
         'sql' => array
         (

--- a/dca/tl_nc_notification.php
+++ b/dca/tl_nc_notification.php
@@ -18,7 +18,7 @@ $GLOBALS['TL_DCA']['tl_nc_notification'] = array
     'config' => array
     (
         'ctable'                      => array('tl_nc_message'),
-        'dataContainer'               => 'Table',
+        'dataContainer'               => \Contao\DC_Table::class,
         'switchToEdit'                => true,
         'enableVersioning'            => true,
         'sql' => array

--- a/dca/tl_nc_queue.php
+++ b/dca/tl_nc_queue.php
@@ -17,7 +17,7 @@ $GLOBALS['TL_DCA']['tl_nc_queue'] = array
     // Config
     'config' => array
     (
-        'dataContainer'               => 'Table',
+        'dataContainer'               => \Contao\DC_Table::class,
         'closed'                      => true,
         'notEditable'                 => true,
         'notCopyable'                 => true,

--- a/library/NotificationCenter/AutoSuggester.php
+++ b/library/NotificationCenter/AutoSuggester.php
@@ -10,11 +10,16 @@
 
 namespace NotificationCenter;
 
+use Contao\Controller;
+use Contao\Database;
+use Contao\DataContainer;
+use Contao\Input;
 use Contao\StringUtil;
+use Contao\System;
 use NotificationCenter\Model\Notification as NotificationModel;
 
 
-class AutoSuggester extends \Controller
+class AutoSuggester extends Controller
 {
     protected static $strTable;
     protected static $objNotification;
@@ -29,17 +34,17 @@ class AutoSuggester extends \Controller
         }
 
         // @todo implement editAll and overrideAll
-        if ('edit' !== \Input::get('act')) {
+        if ('edit' !== Input::get('act')) {
             return;
         }
 
         // @todo rename to nc_tokens
-        \System::loadLanguageFile('tokens');
+        System::loadLanguageFile('tokens');
         $GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/notification_center/assets/autosuggester' . ($GLOBALS['TL_CONFIG']['debugMode'] ? '' : '.min') . '.js';
         $GLOBALS['TL_CSS'][]        = 'system/modules/notification_center/assets/autosuggester' . ($GLOBALS['TL_CONFIG']['debugMode'] ? '' : '.min') . '.css';
 
         static::$strTable = $dc->table;
-        static::$objNotification = \Database::getInstance()->prepare("SELECT * FROM tl_nc_notification WHERE id=(SELECT pid FROM tl_nc_message WHERE id=(SELECT pid FROM tl_nc_language WHERE id=?))")->execute($dc->id);
+        static::$objNotification = Database::getInstance()->prepare("SELECT * FROM tl_nc_notification WHERE id=(SELECT pid FROM tl_nc_message WHERE id=(SELECT pid FROM tl_nc_language WHERE id=?))")->execute($dc->id);
         static::$strType = static::$objNotification->type;
 
         foreach ($GLOBALS['TL_DCA'][static::$strTable]['fields'] as $field => $arrConfig) {
@@ -53,11 +58,11 @@ class AutoSuggester extends \Controller
     /**
      * Initialize the auto suggester
      *
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      *
      * @return string
      */
-    public function init(\DataContainer $dc)
+    public function init(DataContainer $dc)
     {
         $strGroup  = NotificationModel::findGroupForType(static::$strType);
         $arrTokens = $GLOBALS['NOTIFICATION_CENTER']['NOTIFICATION_TYPE'][$strGroup][static::$strType][$dc->field] ?? [];
@@ -203,7 +208,7 @@ window.addEvent('domready', function() {
         }
 
         try {
-            \StringUtil::parseSimpleTokens($strText, array_flip($foundTokens));
+            StringUtil::parseSimpleTokens($strText, array_flip($foundTokens));
         } catch (\Exception $e) {
             $objWidget->addError($e->getMessage());
 
@@ -220,7 +225,7 @@ window.addEvent('domready', function() {
         }
 
         $tokens = [];
-        $templates = deserialize(static::$objNotification->templates, true);
+        $templates = StringUtil::deserialize(static::$objNotification->templates, true);
 
         foreach ($templates as $template) {
             $tokens[] = 'template_'.substr($template, 13);

--- a/library/NotificationCenter/AutoSuggester.php
+++ b/library/NotificationCenter/AutoSuggester.php
@@ -208,7 +208,7 @@ window.addEvent('domready', function() {
         }
 
         try {
-            StringUtil::parseSimpleTokens($strText, array_flip($foundTokens));
+            System::getContainer()->get('contao.string.simple_token_parser')->parse($strText, array_flip($foundTokens));
         } catch (\Exception $e) {
             $objWidget->addError($e->getMessage());
 

--- a/library/NotificationCenter/ContaoHelper.php
+++ b/library/NotificationCenter/ContaoHelper.php
@@ -49,7 +49,7 @@ class ContaoHelper extends Controller
         // Only create opt-in token if the ##link## simple token is in use (#237)
         if (null !== $notification && $notification->hasToken('link')) {
             /** @var \Contao\CoreBundle\OptIn\OptIn $optIn */
-            $optIn      = \Contao\System::getContainer()->get('contao.opt-in');
+            $optIn      = System::getContainer()->get('contao.opt-in');
             $optInToken = $optIn->create('reg-', $arrData['email'], array('tl_member' => array($arrData['id'])));
 
             $arrData['activation'] = $optInToken->getIdentifier();
@@ -146,7 +146,7 @@ class ContaoHelper extends Controller
             }
         }
 
-        $objNotification = \NotificationCenter\Model\Notification::findByPk($intNotification);
+        $objNotification = Notification::findByPk($intNotification);
 
         if ($objNotification !== null) {
             $objNotification->send($arrTokens, $GLOBALS['TL_LANGUAGE']);

--- a/library/NotificationCenter/Gateway/Base.php
+++ b/library/NotificationCenter/Gateway/Base.php
@@ -37,8 +37,7 @@ abstract class Base extends Controller
 
     /**
      * Set notification type and models
-     * @param   Notification
-     * @param   Gateway
+     * @param   Gateway $objModel
      */
     public function __construct(Gateway $objModel)
     {
@@ -47,7 +46,7 @@ abstract class Base extends Controller
 
     /**
      * Gets the gateway model
-     * @return  \NotificationCenter\Model\Gateway
+     * @return  Gateway
      */
     public function getModel()
     {

--- a/library/NotificationCenter/Gateway/Email.php
+++ b/library/NotificationCenter/Gateway/Email.php
@@ -10,6 +10,7 @@
 
 namespace NotificationCenter\Gateway;
 
+use Contao\System;
 use NotificationCenter\MessageDraft\EmailMessageDraft;
 use NotificationCenter\MessageDraft\MessageDraftFactoryInterface;
 use NotificationCenter\Model\Language;
@@ -40,7 +41,7 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
         }
 
         if (($objLanguage = Language::findByMessageAndLanguageOrFallback($objMessage, $strLanguage)) === null) {
-            \System::log(sprintf('Could not find matching language or fallback for message ID "%s" and language "%s".', $objMessage->id, $strLanguage), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not find matching language or fallback for message ID "%s" and language "%s".', $objMessage->id, $strLanguage), __METHOD__, TL_ERROR);
 
             return null;
         }
@@ -51,7 +52,7 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
     private function instantiateEmail()
     {
         if (version_compare(VERSION, '4.10', '>=')) {
-            $objEmail = new \Email();
+            $objEmail = new \Contao\Email();
             if ($this->objModel->mailerTransport) {
                 $objEmail->addHeader('X-Transport', $this->objModel->mailerTransport);
             }
@@ -77,10 +78,10 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
                 $transport->setUsername($this->objModel->email_smtpUser)->setPassword($this->objModel->email_smtpPass);
             }
 
-            return new \Email(new \Swift_Mailer($transport));
+            return new \Contao\Email(new \Swift_Mailer($transport));
         }
 
-        $objEmail = new \Email();
+        $objEmail = new \Contao\Email();
         $this->resetSMTPSettings();
 
         return $objEmail;
@@ -109,7 +110,7 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
             try {
                 $objEmail->replyTo($strReplyTo);
             } catch (\Exception $e) {
-                \System::log(sprintf('Could not set reply-to address "%s" for message ID %s: %s', $strReplyTo, $objDraft->getMessage()->id, $e->getMessage()), __METHOD__, TL_ERROR);
+                System::log(sprintf('Could not set reply-to address "%s" for message ID %s: %s', $strReplyTo, $objDraft->getMessage()->id, $e->getMessage()), __METHOD__, TL_ERROR);
                 return false;
             }
         }
@@ -160,13 +161,13 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
         try {
             $blnSent = $objEmail->sendTo($objDraft->getRecipientEmails());
         } catch (\Exception $e) {
-            \System::log(sprintf('Could not send email to "%s" for message ID %s: %s', implode(', ', $objDraft->getRecipientEmails()), $objDraft->getMessage()->id, $e->getMessage()), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not send email to "%s" for message ID %s: %s', implode(', ', $objDraft->getRecipientEmails()), $objDraft->getMessage()->id, $e->getMessage()), __METHOD__, TL_ERROR);
 
             return false;
         }
 
         if (!$blnSent) {
-            \System::log(sprintf('Could not send email to "%s" for message ID %s', implode(', ', $objDraft->getRecipientEmails()), $objDraft->getMessage()->id), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not send email to "%s" for message ID %s', implode(', ', $objDraft->getRecipientEmails()), $objDraft->getMessage()->id), __METHOD__, TL_ERROR);
         }
 
         return $blnSent;
@@ -191,7 +192,7 @@ class Email extends Base implements GatewayInterface, MessageDraftFactoryInterfa
         // return false if no language found for BC
         if ($objDraft === null) {
 
-            \System::log(sprintf('Could not create draft message for e-mail (Message ID: %s)', $objMessage->id), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not create draft message for e-mail (Message ID: %s)', $objMessage->id), __METHOD__, TL_ERROR);
 
             return false;
         }

--- a/library/NotificationCenter/Gateway/File.php
+++ b/library/NotificationCenter/Gateway/File.php
@@ -11,6 +11,8 @@
 namespace NotificationCenter\Gateway;
 
 use Codefog\HasteBundle\StringParser;
+use Contao\Config;
+use Contao\Folder;
 use Contao\System;
 use NotificationCenter\Model\Language;
 use NotificationCenter\Model\Message;
@@ -42,7 +44,7 @@ class File extends Base implements GatewayInterface
         }
 
         if (($objLanguage = Language::findByMessageAndLanguageOrFallback($objMessage, $strLanguage)) === null) {
-            \System::log(sprintf('Could not find matching language or fallback for message ID "%s" and language "%s".', $objMessage->id, $strLanguage), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not find matching language or fallback for message ID "%s" and language "%s".', $objMessage->id, $strLanguage), __METHOD__, TL_ERROR);
 
             return false;
         }
@@ -69,7 +71,7 @@ class File extends Base implements GatewayInterface
         try {
             return $this->save($strFileName, $strContent, (string) $objLanguage->file_storage_mode);
         } catch (\Exception $e) {
-            \System::log('Notification Center gateway error: ' . $e->getMessage(), __METHOD__, TL_ERROR);
+            System::log('Notification Center gateway error: ' . $e->getMessage(), __METHOD__, TL_ERROR);
 
             return false;
         }
@@ -167,10 +169,10 @@ class File extends Base implements GatewayInterface
     {
         // Make sure the directory exists
         if (!is_dir(sprintf('%s/%s', TL_ROOT, $this->objModel->file_path))) {
-            $folder = new \Folder($this->objModel->file_path);
+            $folder = new Folder($this->objModel->file_path);
 
-            if (\Config::get('defaultFolderChmod')) {
-                $folder->chmod(\Config::get('defaultFolderChmod'));
+            if (Config::get('defaultFolderChmod')) {
+                $folder->chmod(Config::get('defaultFolderChmod'));
             }
         }
 
@@ -181,7 +183,7 @@ class File extends Base implements GatewayInterface
             $strFileName = $this->getUniqueFileName($strFileName, scan(TL_ROOT . '/' . $this->objModel->file_path, true));
         }
 
-        $objFile = new \File($this->objModel->file_path . '/' . $strFileName);
+        $objFile = new \Contao\File($this->objModel->file_path . '/' . $strFileName);
 
         // Don't start with a newline
         if ($strStorageMode === self::FILE_STORAGE_APPEND
@@ -193,7 +195,7 @@ class File extends Base implements GatewayInterface
 
         $blnResult = $objFile->write($strContent);
         $objFile->close();
-        $objFile->chmod(\Config::get('defaultFileChmod'));
+        $objFile->chmod(Config::get('defaultFileChmod'));
 
         return $blnResult;
     }
@@ -247,7 +249,7 @@ class File extends Base implements GatewayInterface
         }
 
         // Write content to temporary file
-        $objFile = new \File(sys_get_temp_dir() . '/' . md5(uniqid(mt_rand(), true)));
+        $objFile = new \Contao\File(sys_get_temp_dir() . '/' . md5(uniqid(mt_rand(), true)));
         $objFile->write($strContent);
         $objFile->close();
 
@@ -256,7 +258,7 @@ class File extends Base implements GatewayInterface
 
         // Delete temporary file and close FTP connection
         $objFile->delete();
-        @ftp_chmod($resConnection, \Config::get('defaultFileChmod'), $this->objModel->file_path . '/' . $strFileName);
+        @ftp_chmod($resConnection, Config::get('defaultFileChmod'), $this->objModel->file_path . '/' . $strFileName);
         @ftp_close($resConnection);
 
         return $blnResult;

--- a/library/NotificationCenter/Gateway/File.php
+++ b/library/NotificationCenter/Gateway/File.php
@@ -180,7 +180,7 @@ class File extends Base implements GatewayInterface
         if ($strStorageMode === self::FILE_STORAGE_CREATE
             && is_file(TL_ROOT . '/' . $this->objModel->file_path . '/' . $strFileName)
         ) {
-            $strFileName = $this->getUniqueFileName($strFileName, scan(TL_ROOT . '/' . $this->objModel->file_path, true));
+            $strFileName = $this->getUniqueFileName($strFileName, Folder::scan(TL_ROOT . '/' . $this->objModel->file_path, true));
         }
 
         $objFile = new \Contao\File($this->objModel->file_path . '/' . $strFileName);

--- a/library/NotificationCenter/Gateway/LabelCallbackInterface.php
+++ b/library/NotificationCenter/Gateway/LabelCallbackInterface.php
@@ -10,6 +10,8 @@
 
 namespace NotificationCenter\Gateway;
 
+use Contao\DataContainer;
+
 interface LabelCallbackInterface
 {
     /**
@@ -17,10 +19,10 @@ interface LabelCallbackInterface
      *
      * @param array          $row
      * @param string         $label
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      * @param array          $args
      *
      * @return string
      */
-    public function getLabel($row, $label, \DataContainer $dc, $args);
+    public function getLabel($row, $label, DataContainer $dc, $args);
 }

--- a/library/NotificationCenter/Gateway/Postmark.php
+++ b/library/NotificationCenter/Gateway/Postmark.php
@@ -10,6 +10,8 @@
 
 namespace NotificationCenter\Gateway;
 
+use Contao\Request;
+use Contao\System;
 use NotificationCenter\MessageDraft\MessageDraftFactoryInterface;
 use NotificationCenter\MessageDraft\PostmarkMessageDraft;
 use NotificationCenter\Model\Language;
@@ -33,7 +35,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
         }
 
         if (($objLanguage = Language::findByMessageAndLanguageOrFallback($objMessage, $strLanguage)) === null) {
-            \System::log(sprintf('Could not find matching language or fallback for message ID "%s" and language "%s".', $objMessage->id, $strLanguage), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not find matching language or fallback for message ID "%s" and language "%s".', $objMessage->id, $strLanguage), __METHOD__, TL_ERROR);
 
             return null;
         }
@@ -51,7 +53,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
     public function send(Message $objMessage, array $arrTokens, $strLanguage = '')
     {
         if ($this->objModel->postmark_key == '') {
-            \System::log(sprintf('Please provide the Postmark API key for message ID "%s"', $objMessage->id), __METHOD__, TL_ERROR);
+            System::log(sprintf('Please provide the Postmark API key for message ID "%s"', $objMessage->id), __METHOD__, TL_ERROR);
 
             return false;
         }
@@ -81,7 +83,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
         $arrBcc = $objDraft->getBccRecipientEmails();
 
         if (count(array_merge($arrTo, $arrCc, $arrBcc)) >= 20) {
-            \System::log(
+            System::log(
                 sprintf('The Postmark gateway does not support sending to more than 20 recipients (CC and BCC included) for message ID "%s".',
                     $objMessage->id
                 ),
@@ -124,7 +126,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
 
         $strData = json_encode($arrData);
 
-        $objRequest = new \Request();
+        $objRequest = new Request();
         $objRequest->setHeader('Content-Type', 'application/json');
         $objRequest->setHeader('X-Postmark-Server-Token', ($this->objModel->postmark_test ? 'POSTMARK_API_TEST' : $this->objModel->postmark_key));
         $objRequest->send(($this->objModel->postmark_ssl ? 'https://' : 'http://') . 'api.postmarkapp.com/email', $strData, 'POST');
@@ -136,7 +138,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
         }
 
         if ($objRequest->hasError()) {
-            \System::log(
+            System::log(
                 sprintf('Error sending the Postmark request for message ID "%s". HTTP Response status code: %s. JSON data sent: %s',
                     $objMessage->id,
                     $code,
@@ -148,7 +150,7 @@ class Postmark extends Base implements GatewayInterface, MessageDraftFactoryInte
             return false;
         } else {
             $strWouldHave = ($this->objModel->postmark_test) ? ' would have (test mode)' : '';
-            \System::log(
+            System::log(
                 sprintf('The Postmark API accepted the request and%s sent %s emails. HTTP Response status code: %s. JSON data sent: %s',
                     $strWouldHave,
                     count($arrTo),

--- a/library/NotificationCenter/Gateway/Queue.php
+++ b/library/NotificationCenter/Gateway/Queue.php
@@ -11,6 +11,7 @@
 namespace NotificationCenter\Gateway;
 
 
+use Contao\DataContainer;
 use NotificationCenter\Model\Gateway;
 use NotificationCenter\Model\Message;
 
@@ -37,12 +38,12 @@ class Queue implements GatewayInterface, LabelCallbackInterface
      *
      * @param array          $row
      * @param string         $label
-     * @param \DataContainer $dc
+     * @param DataContainer $dc
      * @param array          $args
      *
      * @return string
      */
-    public function getLabel($row, $label, \DataContainer $dc, $args)
+    public function getLabel($row, $label, DataContainer $dc, $args)
     {
         $targetModel = Gateway::findByPk($row['queue_targetGateway']);
 

--- a/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
+++ b/library/NotificationCenter/MessageDraft/EmailMessageDraft.php
@@ -13,7 +13,10 @@ namespace NotificationCenter\MessageDraft;
 
 use Codefog\HasteBundle\StringParser;
 use Contao\Config;
+use Contao\Controller;
 use Contao\File;
+use Contao\FilesModel;
+use Contao\FrontendTemplate;
 use Contao\System;
 use NotificationCenter\Model\Language;
 use NotificationCenter\Model\Message;
@@ -158,7 +161,7 @@ class EmailMessageDraft implements MessageDraftInterface
         $strText = $this->objLanguage->email_text;
         $strText = System::getContainer()->get(StringParser::class)->recursiveReplaceTokensAndTags($strText, $this->arrTokens, StringUtil::NO_TAGS);
 
-        return \Controller::convertRelativeUrls($strText, '', true);
+        return Controller::convertRelativeUrls($strText, '', true);
     }
 
     /**
@@ -168,7 +171,7 @@ class EmailMessageDraft implements MessageDraftInterface
     public function getHtmlBody()
     {
         if ($this->objLanguage->email_mode == 'textAndHtml') {
-            $objTemplate          = new \FrontendTemplate($this->objMessage->email_template);
+            $objTemplate          = new FrontendTemplate($this->objMessage->email_template);
             $objTemplate->body    = $this->objLanguage->email_html;
             $objTemplate->charset = $GLOBALS['TL_CONFIG']['characterSet'];
 
@@ -176,7 +179,7 @@ class EmailMessageDraft implements MessageDraftInterface
             $GLOBALS['TL_CONFIG']['allowedTags'] .= '<doctype><html><head><meta><style><body>';
             $strHtml = str_replace('<!DOCTYPE', '<DOCTYPE', $objTemplate->parse());
             $strHtml = System::getContainer()->get(StringParser::class)->recursiveReplaceTokensAndTags($strHtml, $this->arrTokens);
-            $strHtml = \Controller::convertRelativeUrls($strHtml, '', true);
+            $strHtml = Controller::convertRelativeUrls($strHtml, '', true);
             $strHtml = str_replace('<DOCTYPE', '<!DOCTYPE', $strHtml);
 
             return $strHtml;
@@ -209,7 +212,7 @@ class EmailMessageDraft implements MessageDraftInterface
             $arrStaticAttachments = \Contao\StringUtil::deserialize($this->objLanguage->attachments, true);
 
             if (!empty($arrStaticAttachments)) {
-                $objFiles = \FilesModel::findMultipleByUuids($arrStaticAttachments);
+                $objFiles = FilesModel::findMultipleByUuids($arrStaticAttachments);
 
                 if ($objFiles !== null) {
                     while ($objFiles->next()) {
@@ -231,10 +234,10 @@ class EmailMessageDraft implements MessageDraftInterface
         if ($this->stringAttachments === null) {
 
             // Add attachment templates
-            $arrTemplateAttachments = deserialize($this->objLanguage->attachment_templates, true);
+            $arrTemplateAttachments = \Contao\StringUtil::deserialize($this->objLanguage->attachment_templates, true);
 
             if (!empty($arrTemplateAttachments)) {
-                $objFiles = \FilesModel::findMultipleByUuids($arrTemplateAttachments);
+                $objFiles = FilesModel::findMultipleByUuids($arrTemplateAttachments);
 
                 if ($objFiles !== null) {
                     while ($objFiles->next()) {

--- a/library/NotificationCenter/Model/Gateway.php
+++ b/library/NotificationCenter/Model/Gateway.php
@@ -11,6 +11,7 @@
 namespace NotificationCenter\Model;
 
 use Contao\Model;
+use Contao\System;
 use NotificationCenter\Gateway\GatewayInterface;
 
 class Gateway extends Model
@@ -39,7 +40,7 @@ class Gateway extends Model
         if (null === $this->objGateway) {
             $strClass = $GLOBALS['NOTIFICATION_CENTER']['GATEWAY'][$this->type];
             if (!class_exists($strClass)) {
-                \System::log(sprintf('Could not find gateway class "%s".', $strClass), __METHOD__, TL_ERROR);
+                System::log(sprintf('Could not find gateway class "%s".', $strClass), __METHOD__, TL_ERROR);
 
                 return null;
             }
@@ -48,7 +49,7 @@ class Gateway extends Model
                 $objGateway = new $strClass($this);
 
                 if (!$objGateway instanceof GatewayInterface) {
-                    \System::log(sprintf('The gateway class "%s" must be an instance of GatewayInterface.', $strClass), __METHOD__, TL_ERROR);
+                    System::log(sprintf('The gateway class "%s" must be an instance of GatewayInterface.', $strClass), __METHOD__, TL_ERROR);
 
                     return null;
                 }
@@ -56,7 +57,7 @@ class Gateway extends Model
                 $this->objGateway = $objGateway;
 
             } catch (\Exception $e) {
-                \System::log(sprintf('There was a general error building the gateway: "%s".', $e->getMessage()), __METHOD__, TL_ERROR);
+                System::log(sprintf('There was a general error building the gateway: "%s".', $e->getMessage()), __METHOD__, TL_ERROR);
 
                 return null;
             }

--- a/library/NotificationCenter/Model/Language.php
+++ b/library/NotificationCenter/Model/Language.php
@@ -10,6 +10,8 @@
 
 namespace NotificationCenter\Model;
 
+use Contao\Model;
+
 /**
  * @property int    $id
  * @property int    $pid
@@ -33,7 +35,7 @@ namespace NotificationCenter\Model;
  * @property string $file_storage_mode
  * @property string $file_content
  */
-class Language extends \Model
+class Language extends Model
 {
 
     /**

--- a/library/NotificationCenter/Model/Message.php
+++ b/library/NotificationCenter/Model/Message.php
@@ -10,9 +10,11 @@
 
 namespace NotificationCenter\Model;
 
+use Contao\Model;
+use Contao\System;
 use NotificationCenter\Gateway\Email;
 
-class Message extends \Model
+class Message extends Model
 {
 
     /**
@@ -46,13 +48,13 @@ class Message extends \Model
     {
         /** @var Gateway $objGatewayModel */
         if (($objGatewayModel = $this->getRelated('gateway')) === null) {
-            \System::log(sprintf('Could not find gateway ID "%s".', $this->gateway), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not find gateway ID "%s".', $this->gateway), __METHOD__, TL_ERROR);
 
             return false;
         }
 
         if (null === $objGatewayModel->getGateway()) {
-            \System::log(sprintf('Could not find gateway class for gateway ID "%s".', $objGatewayModel->id), __METHOD__, TL_ERROR);
+            System::log(sprintf('Could not find gateway class for gateway ID "%s".', $objGatewayModel->id), __METHOD__, TL_ERROR);
 
             return false;
         }
@@ -64,7 +66,7 @@ class Message extends \Model
 
         if (isset($GLOBALS['TL_HOOKS']['sendNotificationMessage']) && is_array($GLOBALS['TL_HOOKS']['sendNotificationMessage'])) {
             foreach ($GLOBALS['TL_HOOKS']['sendNotificationMessage'] as $arrCallback) {
-                $blnSuccess = \System::importStatic($arrCallback[0])->{$arrCallback[1]}($this, $cpTokens, $cpLanguage, $objGatewayModel);
+                $blnSuccess = System::importStatic($arrCallback[0])->{$arrCallback[1]}($this, $cpTokens, $cpLanguage, $objGatewayModel);
 
                 if (!$blnSuccess) {
                     return false;
@@ -87,7 +89,7 @@ class Message extends \Model
 
             // return false if no language found for BC
             if ($objDraft === null) {
-                \System::log(sprintf('Could not create draft message for e-mail (Message ID: %s)', $this->id), __METHOD__, TL_ERROR);
+                System::log(sprintf('Could not create draft message for e-mail (Message ID: %s)', $this->id), __METHOD__, TL_ERROR);
 
                 return false;
             }

--- a/library/NotificationCenter/Model/Notification.php
+++ b/library/NotificationCenter/Model/Notification.php
@@ -12,6 +12,7 @@ namespace NotificationCenter\Model;
 
 use Contao\FrontendTemplate;
 use Contao\Model;
+use Contao\StringUtil;
 use Contao\System;
 
 class Notification extends Model
@@ -97,7 +98,7 @@ class Notification extends Model
 
     private function addTemplateTokens(array $tokens)
     {
-        $templates = deserialize($this->templates, true);
+        $templates = StringUtil::deserialize($this->templates, true);
 
         foreach ($templates as $name) {
             try {

--- a/library/NotificationCenter/Model/Notification.php
+++ b/library/NotificationCenter/Model/Notification.php
@@ -10,7 +10,9 @@
 
 namespace NotificationCenter\Model;
 
+use Contao\FrontendTemplate;
 use Contao\Model;
+use Contao\System;
 
 class Notification extends Model
 {
@@ -40,7 +42,7 @@ class Notification extends Model
     {
         // Check if there are valid messages
         if (($objMessages = $this->getMessages()) === null) {
-            \System::log('Could not find any messages for notification ID ' . $this->id, __METHOD__, TL_ERROR);
+            System::log('Could not find any messages for notification ID ' . $this->id, __METHOD__, TL_ERROR);
 
             return array();
         }
@@ -99,12 +101,12 @@ class Notification extends Model
 
         foreach ($templates as $name) {
             try {
-                $template = new \FrontendTemplate($name);
+                $template = new FrontendTemplate($name);
                 $template->setData($tokens);
 
                 $tokens['template_'.substr($name, 13)] = $template->parse();
             } catch (\Exception $e) {
-                \System::log('Could not generate token template "'.$name.'"', __METHOD__, TL_ERROR);
+                System::log('Could not generate token template "'.$name.'"', __METHOD__, TL_ERROR);
             }
         }
 

--- a/library/NotificationCenter/Model/QueuedMessage.php
+++ b/library/NotificationCenter/Model/QueuedMessage.php
@@ -10,7 +10,10 @@
 
 namespace NotificationCenter\Model;
 
-class QueuedMessage extends \Model
+use Contao\Model;
+use Contao\System;
+
+class QueuedMessage extends Model
 {
 
     /**
@@ -105,7 +108,7 @@ class QueuedMessage extends \Model
     {
         $message = $this->getRelated('message');
         if ($message === null) {
-            \System::log('Could not send queued message ' . $this->id . ' because related message could not be found.', __METHOD__, TL_ERROR);
+            System::log('Could not send queued message ' . $this->id . ' because related message could not be found.', __METHOD__, TL_ERROR);
 
             return false;
         } else {

--- a/library/NotificationCenter/Queue/QueueManager.php
+++ b/library/NotificationCenter/Queue/QueueManager.php
@@ -10,6 +10,7 @@
 
 namespace NotificationCenter\Queue;
 
+use Contao\Database;
 use Contao\Folder;
 use NotificationCenter\Gateway\GatewayInterface;
 use NotificationCenter\MessageDraft\EmailMessageDraft;
@@ -74,7 +75,7 @@ class QueueManager implements QueueManagerInterface
      */
     public function removeMessage(Message $message)
     {
-        \Database::getInstance()->prepare('DELETE FROM tl_nc_queue WHERE message=?')
+        Database::getInstance()->prepare('DELETE FROM tl_nc_queue WHERE message=?')
             ->execute($message->id);
 
         return $this;

--- a/library/NotificationCenter/Util/StringUtil.php
+++ b/library/NotificationCenter/Util/StringUtil.php
@@ -13,6 +13,7 @@ namespace NotificationCenter\Util;
 
 use Codefog\HasteBundle\StringParser;
 use Contao\System;
+use Contao\Validator;
 
 class StringUtil
 {
@@ -76,7 +77,7 @@ class StringUtil
         foreach (\Contao\StringUtil::trimsplit(',', $strAttachmentTokens) as $strToken) {
             $strParsedToken = System::getContainer()->get(StringParser::class)->recursiveReplaceTokensAndTags($strToken, $arrTokens, static::NO_TAGS | static::NO_BREAKS);
 
-            foreach (trimsplit(',', $strParsedToken) as $strFile) {
+            foreach (\Contao\StringUtil::trimsplit(',', $strParsedToken) as $strFile) {
                 if (is_file($strFile)) {
                     $arrAttachments[$strFile] = $strFile;
                     continue;
@@ -110,10 +111,10 @@ class StringUtil
 
         foreach ((array) \Contao\StringUtil::trimsplit(',', $strRecipients) as $strAddress) {
             if ($strAddress != '') {
-                list($strName, $strEmail) = \StringUtil::splitFriendlyEmail($strAddress);
+                list($strName, $strEmail) = \Contao\StringUtil::splitFriendlyEmail($strAddress);
 
                 // Address could become empty through invalid insert tag
-                if ($strAddress == '' || !\Validator::isEmail($strEmail)) {
+                if ($strAddress == '' || !Validator::isEmail($strEmail)) {
                     continue;
                 }
 

--- a/modules/ModuleNewsletterActivateNotificationCenter.php
+++ b/modules/ModuleNewsletterActivateNotificationCenter.php
@@ -26,7 +26,7 @@ class ModuleNewsletterActivateNotificationCenter extends Module
     public function generate()
     {
         if (TL_MODE == 'BE') {
-            $objTemplate = new \BackendTemplate('be_wildcard');
+            $objTemplate = new BackendTemplate('be_wildcard');
             $objTemplate->wildcard = '### ' . strtoupper($GLOBALS['TL_LANG']['FMD']['newsletterActivateNotificationCenter'][0]) . ' ###';
             $objTemplate->title = $this->headline;
             $objTemplate->id = $this->id;
@@ -36,7 +36,7 @@ class ModuleNewsletterActivateNotificationCenter extends Module
             return $objTemplate->parse();
         }
 
-        if (!\Input::get('token')) {
+        if (!Input::get('token')) {
             return '';
         }
 
@@ -45,7 +45,7 @@ class ModuleNewsletterActivateNotificationCenter extends Module
 
     protected function compile()
     {
-        $this->activateRecipient(\Input::get('token'));
+        $this->activateRecipient(Input::get('token'));
     }
 
     /**
@@ -62,7 +62,7 @@ class ModuleNewsletterActivateNotificationCenter extends Module
             }
 
             /** @var \Contao\CoreBundle\OptIn\OptIn $optIn */
-            $optIn = \System::getContainer()->get('contao.opt-in');
+            $optIn = System::getContainer()->get('contao.opt-in');
 
             if ((!$optInToken = $optIn->find($token)) || !$optInToken->isValid() || \count($arrRelated = $optInToken->getRelatedRecords()) < 1 || key($arrRelated) != 'tl_newsletter_recipients' || \count($arrIds = current($arrRelated)) < 1)
             {
@@ -102,7 +102,7 @@ class ModuleNewsletterActivateNotificationCenter extends Module
 
             $strEmail = $optInToken->getEmail();
         } else {
-            $objRecipient = \NewsletterRecipientsModel::findByToken($token);
+            $objRecipient = NewsletterRecipientsModel::findByToken($token);
 
             if ($objRecipient === null) {
                 $this->Template->mclass = 'error';
@@ -172,18 +172,18 @@ class ModuleNewsletterActivateNotificationCenter extends Module
             return;
         }
 
-        $objChannel = \NewsletterChannelModel::findByIds($arrCids);
+        $objChannel = NewsletterChannelModel::findByIds($arrCids);
         $arrChannels = $objChannel ? $objChannel->fetchEach('title') : [];
 
         // Prepare the simple token data
         $arrData = array();
         $arrData['recipient_email'] = $strEmail;
-        $arrData['domain'] = \Idna::decode(\Environment::get('host'));
+        $arrData['domain'] = Idna::decode(Environment::get('host'));
         $arrData['channels'] = implode(', ', $arrChannels);
         $arrData['channel_ids'] = implode(', ', $arrCids);
         $arrData['admin_email'] = $GLOBALS['TL_ADMIN_EMAIL'];
         $arrData['admin_name'] = $GLOBALS['TL_ADMIN_NAME'];
-        $arrData['subject'] = sprintf($GLOBALS['TL_LANG']['MSC']['nl_subject'], \Idna::decode(\Environment::get('host')));
+        $arrData['subject'] = sprintf($GLOBALS['TL_LANG']['MSC']['nl_subject'], Idna::decode(Environment::get('host')));
 
         $objNotification->send($arrData);
     }

--- a/modules/ModuleNewsletterActivateNotificationCenter.php
+++ b/modules/ModuleNewsletterActivateNotificationCenter.php
@@ -187,4 +187,8 @@ class ModuleNewsletterActivateNotificationCenter extends Module
 
         $objNotification->send($arrData);
     }
+
+    protected function validateForm() {
+        throw new \BadMethodCallException('This method is not supported in this class');
+    }
 }

--- a/modules/ModuleNewsletterUnsubscribeNotificationCenter.php
+++ b/modules/ModuleNewsletterUnsubscribeNotificationCenter.php
@@ -34,7 +34,7 @@ class ModuleNewsletterUnsubscribeNotificationCenter extends ModuleUnsubscribe
         $this->Template->channels = $this->compileChannels();
         $this->Template->showChannels = !$this->nl_hideChannels;
         $this->Template->email = Input::get('email');
-        $this->Template->submit = specialchars($GLOBALS['TL_LANG']['MSC']['unsubscribe']);
+        $this->Template->submit = StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['unsubscribe']);
         $this->Template->channelsLabel = $GLOBALS['TL_LANG']['MSC']['nl_channels'];
         $this->Template->emailLabel = $GLOBALS['TL_LANG']['MSC']['emailAddress'];
         $this->Template->action = Environment::get('indexFreeRequest');

--- a/modules/ModulePasswordNotificationCenter.php
+++ b/modules/ModulePasswordNotificationCenter.php
@@ -30,7 +30,9 @@
 namespace Contao;
 
 
-class ModulePasswordNotificationCenter extends \ModulePassword
+use NotificationCenter\Model\Notification;
+
+class ModulePasswordNotificationCenter extends ModulePassword
 {
 
 	/**
@@ -39,7 +41,7 @@ class ModulePasswordNotificationCenter extends \ModulePassword
 	 */
 	protected function sendPasswordLink($objMember)
 	{
-		$objNotification = \NotificationCenter\Model\Notification::findByPk($this->nc_notification);
+		$objNotification = Notification::findByPk($this->nc_notification);
 
 		if ($objNotification === null) {
 			$this->log('The notification was not found ID ' . $this->nc_notification, __METHOD__, TL_ERROR);
@@ -59,7 +61,7 @@ class ModulePasswordNotificationCenter extends \ModulePassword
 
 		if (!version_compare($contaoVersion, '4.7.0', '>=')) {
 			// Store the token
-			$objMember = \MemberModel::findByPk($objMember->id);
+			$objMember = MemberModel::findByPk($objMember->id);
 			$objMember->activation = $token;
 			$objMember->save();
 		}
@@ -73,8 +75,8 @@ class ModulePasswordNotificationCenter extends \ModulePassword
 		}
 
 		$arrTokens['recipient_email'] = $objMember->email;
-		$arrTokens['domain'] = \Idna::decode(\Environment::get('host'));
-		$arrTokens['link'] = \Idna::decode(\Environment::get('base')) . \Environment::get('request') . ((($GLOBALS['TL_CONFIG']['disableAlias'] ?? false) || strpos(\Environment::get('request'), '?') !== false) ? '&' : '?') . 'token=' . $token;
+		$arrTokens['domain'] = Idna::decode(Environment::get('host'));
+		$arrTokens['link'] = Idna::decode(Environment::get('base')) . Environment::get('request') . ((($GLOBALS['TL_CONFIG']['disableAlias'] ?? false) || strpos(Environment::get('request'), '?') !== false) ? '&' : '?') . 'token=' . $token;
 
 		$objNotification->send($arrTokens, $GLOBALS['TL_LANGUAGE']);
 		$this->log('A new password has been requested for user ID ' . $objMember->id . ' (' . $objMember->email . ')', __METHOD__, TL_ACCESS);

--- a/modules/NewsletterModuleTrait.php
+++ b/modules/NewsletterModuleTrait.php
@@ -16,7 +16,7 @@ trait NewsletterModuleTrait
     protected function setCustomTemplate()
     {
         if ($this->nl_template) {
-            $this->Template = new \FrontendTemplate($this->nl_template);
+            $this->Template = new FrontendTemplate($this->nl_template);
             $this->Template->setData($this->arrData);
         }
     }
@@ -37,7 +37,7 @@ trait NewsletterModuleTrait
             'eval'      => ['mandatory' => true]
         ];
 
-        return new \FormCaptcha(\FormCaptcha::getAttributesFromDca($arrField, $arrField['name']));
+        return new FormCaptcha(FormCaptcha::getAttributesFromDca($arrField, $arrField['name']));
     }
 
     /**
@@ -47,7 +47,7 @@ trait NewsletterModuleTrait
      */
     protected function processForm($strFormId, $objCaptchaWidget, $strCallback)
     {
-        if (\Input::post('FORM_SUBMIT') == $strFormId)
+        if (Input::post('FORM_SUBMIT') == $strFormId)
         {
             $varSubmitted = $this->validateForm($objCaptchaWidget);
 
@@ -61,7 +61,7 @@ trait NewsletterModuleTrait
     protected function compileChannels()
     {
         $arrChannels = array();
-        $objChannel = \NewsletterChannelModel::findByIds($this->nl_channels);
+        $objChannel = NewsletterChannelModel::findByIds($this->nl_channels);
 
         // Get the titles
         if ($objChannel !== null)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 0
+
+    paths:
+        - modules
+        - library
+        - dca
+        - classes
+        - bin


### PR DESCRIPTION
I'm aware of #277 but I still wanted to fix some deprecations in the current version until version 2 will be released.
This PR introduces Phpstan as a dev dependency (with level 0), 
fixes usage of the global alias of Contao classes (e.g. `\Input` -> `\Contao\Input`) and 
fixes some deprecated global function usages (e.g. `\trimsplit` -> `StringUtil::trimsplit`).