### PR TITLE
Update tl_nc_language.php

### DIFF
--- a/contao/dca/tl_nc_language.php
+++ b/contao/dca/tl_nc_language.php
@@ -103,6 +103,7 @@ $GLOBALS['TL_DCA']['tl_nc_language'] = [
             'exclude' => true,
             'inputType' => 'checkbox',
             'eval' => ['doNotCopy' => true, 'tl_class' => 'w50 m12'],
+            'default' => 0,
             'sql' => ['type' => 'boolean', 'default' => false],
         ],
         'recipients' => [


### PR DESCRIPTION
Fixes SQL query Exception when a tl_nc_message with at least one tl_nc_language record is copied:
![image](https://github.com/terminal42/contao-notification_center/assets/2776658/1ae18ab5-7683-4024-b55d-1d73d0ea4c2a)
