### PR TITLE
Add support for friendly admin emails

### DIFF
--- a/contao/languages/de/nc_tokens.xlf
+++ b/contao/languages/de/nc_tokens.xlf
@@ -3,8 +3,12 @@
   <file datatype="php" source-language="en" target-language="de">
     <body>
       <trans-unit id="nc_tokens.admin_email">
-        <source>E-mail address of administrator of the current page (website root settings).</source>
-        <target>E-Mail-Adresse des Administrators der aktuellen Seite (Einstellungen der Rootseite).</target>
+        <source>E-mail address of the administrator of the current page (system config or website root settings).</source>
+        <target>E-Mail-Adresse des Administrators der aktuellen Seite (Systemeinstellungen oder Einstellungen der Rootseite).</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.admin_name">
+        <source>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</source>
+        <target>Anzeigename für die E-Mail-Adresse des Administrators der aktuellen Seite (Systemeinstellungen oder Einstellungen der Rootseite).</target>
       </trans-unit>
       <trans-unit id="nc_tokens.form.form_*">
         <source>All the form fields.</source>

--- a/contao/languages/en/nc_tokens.xlf
+++ b/contao/languages/en/nc_tokens.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="nc_tokens.admin_name">
         <source>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</source>
-        <target>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</source>
+        <target>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</target>
       </trans-unit>
       <trans-unit id="nc_tokens.admin_email">
         <source>E-mail address of the administrator of the current page (system config or website root settings).</source>

--- a/contao/languages/en/nc_tokens.xlf
+++ b/contao/languages/en/nc_tokens.xlf
@@ -2,9 +2,13 @@
 <xliff version="1.2">
   <file datatype="php" source-language="en" target-language="en">
     <body>
+      <trans-unit id="nc_tokens.admin_name">
+        <source>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</source>
+        <target>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</source>
+      </trans-unit>
       <trans-unit id="nc_tokens.admin_email">
-        <source>E-mail address of administrator of the current page (website root settings).</source>
-        <target>E-mail address of administrator of the current page (website root settings).</target>
+        <source>E-mail address of the administrator of the current page (system config or website root settings).</source>
+        <target>E-mail address of the administrator of the current page (system config or website root settings).</target>
       </trans-unit>
       <trans-unit id="nc_tokens.form.form_*">
         <source>All the form fields.</source>

--- a/contao/languages/en/nc_tokens.xlf
+++ b/contao/languages/en/nc_tokens.xlf
@@ -2,13 +2,13 @@
 <xliff version="1.2">
   <file datatype="php" source-language="en" target-language="en">
     <body>
-      <trans-unit id="nc_tokens.admin_name">
-        <source>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</source>
-        <target>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</target>
-      </trans-unit>
       <trans-unit id="nc_tokens.admin_email">
         <source>E-mail address of the administrator of the current page (system config or website root settings).</source>
         <target>E-mail address of the administrator of the current page (system config or website root settings).</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.admin_name">
+        <source>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</source>
+        <target>Friendly name for the e-mail address of the administrator of the current page (system config or website root settings).</target>
       </trans-unit>
       <trans-unit id="nc_tokens.form.form_*">
         <source>All the form fields.</source>

--- a/src/EventListener/AdminEmailTokenListener.php
+++ b/src/EventListener/AdminEmailTokenListener.php
@@ -15,7 +15,7 @@ use Terminal42\NotificationCenterBundle\Event\GetTokenDefinitionsForNotification
 use Terminal42\NotificationCenterBundle\Parcel\Stamp\TokenCollectionStamp;
 use Terminal42\NotificationCenterBundle\Token\Definition\EmailTokenDefinition;
 use Terminal42\NotificationCenterBundle\Token\Definition\Factory\TokenDefinitionFactoryInterface;
-use Terminal42\NotificationCenterBundle\Token\Token;
+use Terminal42\NotificationCenterBundle\Token\Definition\TokenDefinitionInterface;
 
 class AdminEmailTokenListener
 {
@@ -30,8 +30,8 @@ class AdminEmailTokenListener
     public function onGetTokenDefinitions(GetTokenDefinitionsForNotificationTypeEvent $event): void
     {
         $event
-            ->addTokenDefinition($this->tokenDefinitionFactory->create(EmailTokenDefinition::class, 'admin_name', 'admin_name'))
-            ->addTokenDefinition($this->tokenDefinitionFactory->create(EmailTokenDefinition::class, 'admin_email', 'admin_email'))
+            ->addTokenDefinition($this->getTokenDefinition('admin_email'))
+            ->addTokenDefinition($this->getTokenDefinition('admin_name'))
         ;
     }
 
@@ -53,8 +53,8 @@ class AdminEmailTokenListener
         }
 
         $event->getParcel()->getStamp(TokenCollectionStamp::class)->tokenCollection
-            ->addToken(new Token('admin_name', $email[0], $email[0]))
-            ->addToken(new Token('admin_email', $email[1], $email[1]))
+            ->addToken($this->getTokenDefinition('admin_email')->createToken('admin_email', $email[1]))
+            ->addToken($this->getTokenDefinition('admin_name')->createToken('admin_name', $email[0]))
         ;
     }
 
@@ -80,6 +80,11 @@ class AdminEmailTokenListener
         $email = $this->contaoFramework->getAdapter(Config::class)->get('adminEmail');
 
         return $email ? $this->parseFriendlyEmail($email) : null;
+    }
+
+    private function getTokenDefinition(string $token): TokenDefinitionInterface
+    {
+        return $this->tokenDefinitionFactory->create(EmailTokenDefinition::class, $token, $token);
     }
 
     private function parseFriendlyEmail(string $email): array

--- a/src/Gateway/MailerGateway.php
+++ b/src/Gateway/MailerGateway.php
@@ -104,7 +104,9 @@ class MailerGateway extends AbstractGateway
             $stamp = $stamp->withFrom($from);
         }
 
-        if ('' !== ($fromName = $this->replaceTokensAndInsertTags($parcel, $languageConfig->getString('email_sender_name')))) {
+        $fromName = '' !== $languageConfig->getString('email_sender_name') ? $languageConfig->getString('email_sender_name') : '##admin_name##';
+
+        if ('' !== ($fromName = $this->replaceTokensAndInsertTags($parcel, $fromName))) {
             $stamp = $stamp->withFromName($fromName);
         }
 

--- a/tests/EventListener/AdminEmailTokenSubscriberTest.php
+++ b/tests/EventListener/AdminEmailTokenSubscriberTest.php
@@ -114,12 +114,10 @@ class AdminEmailTokenSubscriberTest extends ContaoTestCase
         $stringUtilAdapter
             ->method('splitFriendlyEmail')
             ->willReturnCallback(
-                static function (string $email): array {
-                    return match ($email) {
-                        'Lorem Ipsum [foobar-config@terminal42.ch]' => ['Lorem Ipsum', 'foobar-config@terminal42.ch'],
-                        'Dolor Sitamet [foobar@terminal42.ch]' => ['Dolor Sitamet', 'foobar@terminal42.ch'],
-                        default => ['', $email],
-                    };
+                static fn(string $email): array => match ($email) {
+                    'Lorem Ipsum [foobar-config@terminal42.ch]' => ['Lorem Ipsum', 'foobar-config@terminal42.ch'],
+                    'Dolor Sitamet [foobar@terminal42.ch]' => ['Dolor Sitamet', 'foobar@terminal42.ch'],
+                    default => ['', $email],
                 },
             )
         ;

--- a/tests/EventListener/AdminEmailTokenSubscriberTest.php
+++ b/tests/EventListener/AdminEmailTokenSubscriberTest.php
@@ -7,7 +7,9 @@ namespace Terminal42\NotificationCenterBundle\Test\EventListener;
 use Contao\Config;
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\PageModel;
+use Contao\StringUtil;
 use Contao\TestCase\ContaoTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Terminal42\NotificationCenterBundle\Config\MessageConfig;
@@ -20,10 +22,11 @@ use Terminal42\NotificationCenterBundle\Token\TokenCollection;
 
 class AdminEmailTokenSubscriberTest extends ContaoTestCase
 {
-    public function testAddsTokenFromPageModel(): void
+    #[DataProvider('adminEmailProvider')]
+    public function testAddsAdminTokens(string $configFriendlyEmail, string $pageFriendlyEmail, string $expectedName, string $expectedEmail): void
     {
         $pageModel = $this->mockClassWithProperties(PageModel::class, [
-            'adminEmail' => 'foobar@terminal42.ch',
+            'adminEmail' => $pageFriendlyEmail,
         ]);
 
         $stack = $this->buildRequestStack($pageModel);
@@ -36,34 +39,43 @@ class AdminEmailTokenSubscriberTest extends ContaoTestCase
         $listener = new AdminEmailTokenListener(
             $stack,
             $tokenDefinitionFactory,
-            $this->mockFrameworkWithAdminEmail('foobar-config@terminal42.ch'),
+            $this->mockFrameworkWithAdminEmail($configFriendlyEmail),
         );
         $listener->onCreateParcel($event);
 
-        $this->assertSame('foobar@terminal42.ch', $tokenCollection->getByName('admin_email')->getValue());
+        $this->assertSame($expectedName, $tokenCollection->getByName('admin_name')->getValue());
+        $this->assertSame($expectedEmail, $tokenCollection->getByName('admin_email')->getValue());
     }
 
-    public function testAddsTokenFromConfig(): void
+    public static function adminEmailProvider(): \Generator
     {
-        $pageModel = $this->mockClassWithProperties(PageModel::class, [
-            'adminEmail' => '',
-        ]);
+        yield 'Basic admin email in config' => [
+            'foobar-config@terminal42.ch',
+            '',
+            '',
+            'foobar-config@terminal42.ch',
+        ];
 
-        $stack = $this->buildRequestStack($pageModel);
-        $tokenCollection = new TokenCollection();
+        yield 'Friendly admin email in config' => [
+            'Lorem Ipsum [foobar-config@terminal42.ch]',
+            '',
+            'Lorem Ipsum',
+            'foobar-config@terminal42.ch',
+        ];
 
-        $event = $this->buildCreateParcelEvent($tokenCollection);
+        yield 'Basic admin email in page' => [
+            'Lorem Ipsum [foobar-config@terminal42.ch]',
+            'foobar@terminal42.ch',
+            '',
+            'foobar@terminal42.ch',
+        ];
 
-        $tokenDefinitionFactory = new CoreTokenDefinitionFactory();
-
-        $listener = new AdminEmailTokenListener(
-            $stack,
-            $tokenDefinitionFactory,
-            $this->mockFrameworkWithAdminEmail('foobar-config@terminal42.ch'),
-        );
-        $listener->onCreateParcel($event);
-
-        $this->assertSame('foobar-config@terminal42.ch', $tokenCollection->getByName('admin_email')->getValue());
+        yield 'Friendly admin email in page' => [
+            'Lorem Ipsum [foobar-config@terminal42.ch]',
+            'Dolor Sitamet [foobar@terminal42.ch]',
+            'Dolor Sitamet',
+            'foobar@terminal42.ch',
+        ];
     }
 
     private function buildRequestStack(PageModel|null $pageModel = null): RequestStack
@@ -86,20 +98,35 @@ class AdminEmailTokenSubscriberTest extends ContaoTestCase
 
     private function mockFrameworkWithAdminEmail(string|null $adminEmail = null): ContaoFramework
     {
-        $adapter = $this->mockAdapter(['isComplete', 'get']);
-        $adapter
+        $configAdapter = $this->mockAdapter(['isComplete', 'get']);
+        $configAdapter
             ->method('isComplete')
             ->willReturn(true)
         ;
 
-        $adapter
+        $configAdapter
             ->method('get')
             ->with('adminEmail')
             ->willReturn($adminEmail)
         ;
 
+        $stringUtilAdapter = $this->mockAdapter(['splitFriendlyEmail']);
+        $stringUtilAdapter
+            ->method('splitFriendlyEmail')
+            ->willReturnCallback(
+                static function (string $email): array {
+                    return match ($email) {
+                        'Lorem Ipsum [foobar-config@terminal42.ch]' => ['Lorem Ipsum', 'foobar-config@terminal42.ch'],
+                        'Dolor Sitamet [foobar@terminal42.ch]' => ['Dolor Sitamet', 'foobar@terminal42.ch'],
+                        default => ['', $email],
+                    };
+                }
+            )
+        ;
+
         return $this->mockContaoFramework([
-            Config::class => $adapter,
+            Config::class => $configAdapter,
+            StringUtil::class => $stringUtilAdapter
         ]);
     }
 }

--- a/tests/EventListener/AdminEmailTokenSubscriberTest.php
+++ b/tests/EventListener/AdminEmailTokenSubscriberTest.php
@@ -114,7 +114,7 @@ class AdminEmailTokenSubscriberTest extends ContaoTestCase
         $stringUtilAdapter
             ->method('splitFriendlyEmail')
             ->willReturnCallback(
-                static fn(string $email): array => match ($email) {
+                static fn (string $email): array => match ($email) {
                     'Lorem Ipsum [foobar-config@terminal42.ch]' => ['Lorem Ipsum', 'foobar-config@terminal42.ch'],
                     'Dolor Sitamet [foobar@terminal42.ch]' => ['Dolor Sitamet', 'foobar@terminal42.ch'],
                     default => ['', $email],

--- a/tests/EventListener/AdminEmailTokenSubscriberTest.php
+++ b/tests/EventListener/AdminEmailTokenSubscriberTest.php
@@ -120,13 +120,13 @@ class AdminEmailTokenSubscriberTest extends ContaoTestCase
                         'Dolor Sitamet [foobar@terminal42.ch]' => ['Dolor Sitamet', 'foobar@terminal42.ch'],
                         default => ['', $email],
                     };
-                }
+                },
             )
         ;
 
         return $this->mockContaoFramework([
             Config::class => $configAdapter,
-            StringUtil::class => $stringUtilAdapter
+            StringUtil::class => $stringUtilAdapter,
         ]);
     }
 }


### PR DESCRIPTION
Currently the notification center will not send an email notification if you are using a friendly email for the administrator email address.

Similiar to https://github.com/terminal42/contao-notification_center/pull/298 this PR fixes that.

_Notes:_

* I wasn't sure whether translations are managed on Transifex or not. I have only adjusted the English translation.
* @Toflar I changed the implementation of how the token values are added to the token collection. Is there a practical difference between
  ```php
  $tokenCollection->addToken(new Token(…))
  ```
  and
  ```php
  $tokenCollection->add($this->tokenDefinitionFactory->create(EmailTokenDefinition::class, …)->createToken())
  ```
  ? For simplicity in this implementation I only used the former to add the token to the collection.