### PR TITLE
Log unsuccessful deliveries to the system log

### DIFF
--- a/config/listeners.php
+++ b/config/listeners.php
@@ -134,7 +134,6 @@ return static function (ContainerConfigurator $container): void {
     ;
 
     $services->set(DbafsMetadataListener::class);
-
     $services->set(LogUnsuccessfulDeliveries::class)
         ->args([
             service('monolog.logger.contao.error')->nullOnInvalid(),

--- a/config/listeners.php
+++ b/config/listeners.php
@@ -19,6 +19,7 @@ use Terminal42\NotificationCenterBundle\EventListener\Backend\DataContainer\Noti
 use Terminal42\NotificationCenterBundle\EventListener\DbafsMetadataListener;
 use Terminal42\NotificationCenterBundle\EventListener\DisableDeliveryListener;
 use Terminal42\NotificationCenterBundle\EventListener\DoctrineSchemaListener;
+use Terminal42\NotificationCenterBundle\EventListener\LogUnsuccessfulDeliveries;
 use Terminal42\NotificationCenterBundle\EventListener\NotificationCenterProListener;
 use Terminal42\NotificationCenterBundle\EventListener\NotificationTypeForModuleListener;
 use Terminal42\NotificationCenterBundle\EventListener\ProcessFormDataListener;
@@ -133,4 +134,10 @@ return static function (ContainerConfigurator $container): void {
     ;
 
     $services->set(DbafsMetadataListener::class);
+
+    $services->set(LogUnsuccessfulDeliveries::class)
+        ->args([
+            service('monolog.logger.contao.error')->nullOnInvalid(),
+        ])
+    ;
 };

--- a/depcheck.php
+++ b/depcheck.php
@@ -10,5 +10,6 @@ return (new Configuration())
         'Contao\ModulePassword', // This class exists in Contao 4.13 but not in 5.3
     ])
     ->ignoreErrorsOnPackage('contao/newsletter-bundle', [ErrorType::DEV_DEPENDENCY_IN_PROD]) // This is an optional integration
+    ->ignoreErrorsOnPackage('psr/log', [ErrorType::SHADOW_DEPENDENCY]) // Logging is optional
     ->ignoreErrorsOnPackage('terminal42/dcawizard', [ErrorType::UNUSED_DEPENDENCY]) // This is a widget used in the back end but not inside code
 ;

--- a/src/EventListener/LogUnsuccessfulDeliveries.php
+++ b/src/EventListener/LogUnsuccessfulDeliveries.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Terminal42\NotificationCenterBundle\Event\ReceiptEvent;
+
+#[AsEventListener]
+class LogUnsuccessfulDeliveries
+{
+    public function __construct(private readonly LoggerInterface|null $contaoErrorLogger)
+    {
+    }
+
+    public function __invoke(ReceiptEvent $event): void
+    {
+        if (null === $this->contaoErrorLogger) {
+            return;
+        }
+
+        $receipt = $event->receipt;
+
+        if ($receipt->wasDelivered()) {
+            return;
+        }
+
+        $exception = $receipt->getException();
+
+        $this->contaoErrorLogger->error($exception->getMessage(), ['exception' => $exception]);
+    }
+}


### PR DESCRIPTION
This implements #335

![image](https://github.com/terminal42/contao-notification_center/assets/4970961/0e287923-81eb-4801-855b-4a6ab5007b97)

<img src="https://github.com/terminal42/contao-notification_center/assets/4970961/91a92d9e-e3cf-4075-82a1-ae3553e7dc6d" width="600">