### PR TITLE
Check if gateway still exists

### DIFF
--- a/library/NotificationCenter/Model/Gateway.php
+++ b/library/NotificationCenter/Model/Gateway.php
@@ -38,7 +38,14 @@ class Gateway extends Model
         // We only need to build the gateway once, Model is cached by registry and Gateway does not change between messages
         if (null === $this->objGateway) {
             $strClass = $GLOBALS['NOTIFICATION_CENTER']['GATEWAY'][$this->type] ?? null;
-            if (null === $strClass || !class_exists($strClass)) {
+
+            if (null === $strClass) {
+                \System::log(sprintf('Could not find gateway "%s".', $this->type), __METHOD__, TL_ERROR);
+
+                return null;
+            }
+
+            if (!class_exists($strClass)) {
                 \System::log(sprintf('Could not find gateway class "%s".', $strClass), __METHOD__, TL_ERROR);
 
                 return null;

--- a/library/NotificationCenter/Model/Gateway.php
+++ b/library/NotificationCenter/Model/Gateway.php
@@ -37,8 +37,8 @@ class Gateway extends Model
     {
         // We only need to build the gateway once, Model is cached by registry and Gateway does not change between messages
         if (null === $this->objGateway) {
-            $strClass = $GLOBALS['NOTIFICATION_CENTER']['GATEWAY'][$this->type];
-            if (!class_exists($strClass)) {
+            $strClass = $GLOBALS['NOTIFICATION_CENTER']['GATEWAY'][$this->type] ?? null;
+            if (null === $strClass || !class_exists($strClass)) {
                 \System::log(sprintf('Could not find gateway class "%s".', $strClass), __METHOD__, TL_ERROR);
 
                 return null;


### PR DESCRIPTION
If you uninstall a gateway, the following error will occur in the back end when editing gateways:

```
ErrorException:
Warning: Undefined array key "foobar"

  at vendor\terminal42\notification_center\library\NotificationCenter\Model\Gateway.php:40
  at NotificationCenter\Model\Gateway->getGateway()
     (vendor\terminal42\notification_center\classes\tl_nc_gateway.php:111)
```

This adds appropriate checks for that.