### PR TITLE
Make `nc_notification` mandatory for `newsletterSubscribeNotificationCenter`

### DIFF
--- a/src/EventListener/Backend/DataContainer/ModuleListener.php
+++ b/src/EventListener/Backend/DataContainer/ModuleListener.php
@@ -103,6 +103,7 @@ class ModuleListener
     private function handleNewsletterSubscribeModule(): void
     {
         $GLOBALS['TL_DCA']['tl_module']['palettes']['newsletterSubscribeNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['subscribe'];
+        $GLOBALS['TL_DCA']['tl_module']['fields']['nc_notification']['eval']['mandatory'] = true;
 
         PaletteManipulator::create()
             ->addField('nc_notification', 'email_legend', PaletteManipulator::POSITION_APPEND)


### PR DESCRIPTION
See https://github.com/terminal42/contao-notification_center/discussions/365#discussioncomment-10774933

The `SubscribeController` does not check if a notification was selected:

https://github.com/terminal42/contao-notification_center/blob/0e8563be82f65c463ac686f6052cf114980eefa0/src/Controller/FrontendModule/Newsletter/SubscribeController.php#L80-L82

It should not have to, as it does not make sense to use the NC specific module without a notification anyway. Thus instead the `tl_module.nc_notification` field should simply be mandatory for this front end module.