### PR TITLE
Added FormConfigStamp

### DIFF
--- a/config/listeners.php
+++ b/config/listeners.php
@@ -107,6 +107,7 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             service(NotificationCenter::class),
             service(FileUploadNormalizer::class),
+            service(ConfigLoader::class),
         ])
     ;
 

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -38,6 +38,11 @@ class ConfigLoader implements ResetInterface
         return $this->loadConfig($id, 'tl_module', ModuleConfig::class);
     }
 
+    public function loadForm(int $id): FormConfig|null
+    {
+        return $this->loadConfig($id, 'tl_form', FormConfig::class);
+    }
+
     /**
      * @return array<MessageConfig>
      */

--- a/src/Config/FormConfig.php
+++ b/src/Config/FormConfig.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Config;
+
+class FormConfig extends AbstractConfig
+{
+}

--- a/src/EventListener/ProcessFormDataListener.php
+++ b/src/EventListener/ProcessFormDataListener.php
@@ -9,8 +9,10 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Form;
 use Contao\StringUtil;
 use Terminal42\NotificationCenterBundle\BulkyItem\FileItem;
+use Terminal42\NotificationCenterBundle\Config\ConfigLoader;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
 use Terminal42\NotificationCenterBundle\Parcel\Stamp\BulkyItemsStamp;
+use Terminal42\NotificationCenterBundle\Parcel\Stamp\FormConfigStamp;
 
 #[AsHook('processFormData')]
 class ProcessFormDataListener
@@ -18,6 +20,7 @@ class ProcessFormDataListener
     public function __construct(
         private readonly NotificationCenter $notificationCenter,
         private readonly FileUploadNormalizer $fileUploadNormalizer,
+        private readonly ConfigLoader $configLoader,
     ) {
     }
 
@@ -93,6 +96,12 @@ class ProcessFormDataListener
 
         if (0 !== \count($bulkyItemVouchers)) {
             $stamps = $stamps->with(new BulkyItemsStamp($bulkyItemVouchers));
+        }
+
+        $formConfig = $this->configLoader->loadForm((int) $form->id);
+
+        if (null !== $formConfig) {
+            $stamps = $stamps->with(new FormConfigStamp($formConfig));
         }
 
         $this->notificationCenter->sendNotificationWithStamps((int) $formData['nc_notification'], $stamps);

--- a/src/Parcel/Stamp/FormConfigStamp.php
+++ b/src/Parcel/Stamp/FormConfigStamp.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Parcel\Stamp;
+
+use Terminal42\NotificationCenterBundle\Config\FormConfig;
+
+class FormConfigStamp extends AbstractConfigStamp
+{
+    public function __construct(public FormConfig $formConfig)
+    {
+        parent::__construct($this->formConfig);
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(FormConfig::fromArray($data));
+    }
+}

--- a/src/Token/TokenCollection.php
+++ b/src/Token/TokenCollection.php
@@ -29,6 +29,19 @@ class TokenCollection extends AbstractCollection
         return new self($tokens);
     }
 
+    public function replaceToken(Token $token): self
+    {
+        $existing = $this->getByName($token->getName());
+
+        if (null !== $existing) {
+            $this->remove($existing);
+        }
+
+        $this->addToken($token);
+
+        return $this;
+    }
+
     /**
      * Provides a fluent interface alternative to add() with a type hint.
      */

--- a/tests/Token/TokenCollectionTest.php
+++ b/tests/Token/TokenCollectionTest.php
@@ -67,14 +67,14 @@ class TokenCollectionTest extends TestCase
         $tokenCollection->addToken(Token::fromValue('test', 'foobar'));
         $tokenCollection->addToken(Token::fromValue('test', 'foobar new'));
 
-        $this->assertSame(2, $tokenCollection->count());
+        $this->assertCount(2, $tokenCollection);
         $this->assertSame('foobar', $tokenCollection->getByName('test')->getValue(), 'foobar');
 
         $tokenCollection = new TokenCollection();
         $tokenCollection->replaceToken(Token::fromValue('test', 'foobar'));
         $tokenCollection->replaceToken(Token::fromValue('test', 'foobar new'));
 
-        $this->assertSame(1, $tokenCollection->count());
+        $this->assertCount(1, $tokenCollection);
         $this->assertSame('foobar new', $tokenCollection->getByName('test')->getValue(), 'foobar');
     }
 

--- a/tests/Token/TokenCollectionTest.php
+++ b/tests/Token/TokenCollectionTest.php
@@ -61,6 +61,23 @@ class TokenCollectionTest extends TestCase
         $this->assertNull($tokenCollection->getByName('form_i_do_not_exist'));
     }
 
+    public function testReplace(): void
+    {
+        $tokenCollection = new TokenCollection();
+        $tokenCollection->addToken(Token::fromValue('test', 'foobar'));
+        $tokenCollection->addToken(Token::fromValue('test', 'foobar new'));
+
+        $this->assertSame(2, $tokenCollection->count());
+        $this->assertSame('foobar', $tokenCollection->getByName('test')->getValue(), 'foobar');
+
+        $tokenCollection = new TokenCollection();
+        $tokenCollection->replaceToken(Token::fromValue('test', 'foobar'));
+        $tokenCollection->replaceToken(Token::fromValue('test', 'foobar new'));
+
+        $this->assertSame(1, $tokenCollection->count());
+        $this->assertSame('foobar new', $tokenCollection->getByName('test')->getValue(), 'foobar');
+    }
+
     public function testMerge(): void
     {
         $tokenCollectionA = new TokenCollection();


### PR DESCRIPTION
If using the NC with the form generator, sometimes it would be very handy to know from which form that notification was sent. This is useful in other events and logs etc.