### PR TITLE
Implemented file tokens for bulky items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
         "symfony/mailer": "^5.4 || ^6.0 || ^7.0",
         "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+        "symfony/routing": "^5.4 || ^6.0 || ^7.0",
         "symfony/security-core": "^5.4 || ^6.0 || ^7.0",
         "symfony/service-contracts": "^1.1 || ^2.0 || ^3.0",
         "symfony/translation-contracts": "^2.0 || ^3.0",

--- a/config/listeners.php
+++ b/config/listeners.php
@@ -8,6 +8,7 @@ use Codefog\HasteBundle\FileUploadNormalizer;
 use Codefog\HasteBundle\Formatter;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Terminal42\NotificationCenterBundle\Backend\AutoSuggester;
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 use Terminal42\NotificationCenterBundle\Config\ConfigLoader;
 use Terminal42\NotificationCenterBundle\EventListener\AdminEmailTokenListener;
 use Terminal42\NotificationCenterBundle\EventListener\Backend\BackendMenuListener;
@@ -17,6 +18,7 @@ use Terminal42\NotificationCenterBundle\EventListener\Backend\DataContainer\Lang
 use Terminal42\NotificationCenterBundle\EventListener\Backend\DataContainer\MessageListener;
 use Terminal42\NotificationCenterBundle\EventListener\Backend\DataContainer\ModuleListener;
 use Terminal42\NotificationCenterBundle\EventListener\Backend\DataContainer\NotificationListener;
+use Terminal42\NotificationCenterBundle\EventListener\BulkyItemsTokenListener;
 use Terminal42\NotificationCenterBundle\EventListener\DbafsMetadataListener;
 use Terminal42\NotificationCenterBundle\EventListener\DisableDeliveryListener;
 use Terminal42\NotificationCenterBundle\EventListener\DoctrineSchemaListener;
@@ -97,6 +99,14 @@ return static function (ContainerConfigurator $container): void {
             service('request_stack'),
             service(TokenDefinitionFactoryInterface::class),
             service('contao.framework'),
+        ])
+    ;
+
+    $services->set(BulkyItemsTokenListener::class)
+        ->args([
+            service(BulkyItemStorage::class),
+            service(TokenDefinitionFactoryInterface::class),
+            service('twig'),
         ])
     ;
 

--- a/config/services.php
+++ b/config/services.php
@@ -10,6 +10,7 @@ use Terminal42\NotificationCenterBundle\Backend\AutoSuggester;
 use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 use Terminal42\NotificationCenterBundle\BulkyItem\FileItemFactory;
 use Terminal42\NotificationCenterBundle\Config\ConfigLoader;
+use Terminal42\NotificationCenterBundle\Controller\DownloadBulkyItemController;
 use Terminal42\NotificationCenterBundle\Cron\PruneBulkyItemStorageCron;
 use Terminal42\NotificationCenterBundle\DependencyInjection\Terminal42NotificationCenterExtension;
 use Terminal42\NotificationCenterBundle\Gateway\GatewayRegistry;
@@ -29,6 +30,14 @@ return static function (ContainerConfigurator $container): void {
             service(NotificationCenter::class),
             service(TranslatorInterface::class),
         ])
+    ;
+
+    $services->set(DownloadBulkyItemController::class)
+        ->args([
+            service('uri_signer'),
+            service(BulkyItemStorage::class),
+        ])
+        ->public()
     ;
 
     $services->set(GatewayRegistry::class)
@@ -57,6 +66,8 @@ return static function (ContainerConfigurator $container): void {
     $services->set(BulkyItemStorage::class)
         ->args([
             service('contao.filesystem.virtual.'.Terminal42NotificationCenterExtension::BULKY_ITEMS_VFS_NAME),
+            service('router'),
+            service('uri_signer'),
         ])
     ;
 

--- a/config/services.php
+++ b/config/services.php
@@ -20,6 +20,7 @@ use Terminal42\NotificationCenterBundle\Token\Definition\Factory\ChainTokenDefin
 use Terminal42\NotificationCenterBundle\Token\Definition\Factory\CoreTokenDefinitionFactory;
 use Terminal42\NotificationCenterBundle\Token\Definition\Factory\TokenDefinitionFactoryInterface;
 use Terminal42\NotificationCenterBundle\Twig\NotificationCenterExtension;
+use Terminal42\NotificationCenterBundle\Twig\NotificationCenterRuntime;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -84,7 +85,8 @@ return static function (ContainerConfigurator $container): void {
         ])
     ;
 
-    $services->set(NotificationCenterExtension::class)
+    $services->set(NotificationCenterExtension::class);
+    $services->set(NotificationCenterRuntime::class)
         ->args([
             service(BulkyItemStorage::class),
         ])

--- a/config/services.php
+++ b/config/services.php
@@ -19,6 +19,7 @@ use Terminal42\NotificationCenterBundle\NotificationType\NotificationTypeRegistr
 use Terminal42\NotificationCenterBundle\Token\Definition\Factory\ChainTokenDefinitionFactory;
 use Terminal42\NotificationCenterBundle\Token\Definition\Factory\CoreTokenDefinitionFactory;
 use Terminal42\NotificationCenterBundle\Token\Definition\Factory\TokenDefinitionFactoryInterface;
+use Terminal42\NotificationCenterBundle\Twig\NotificationCenterExtension;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -78,6 +79,12 @@ return static function (ContainerConfigurator $container): void {
     ;
 
     $services->set(PruneBulkyItemStorageCron::class)
+        ->args([
+            service(BulkyItemStorage::class),
+        ])
+    ;
+
+    $services->set(NotificationCenterExtension::class)
         ->args([
             service(BulkyItemStorage::class),
         ])

--- a/contao/templates/notification_center/file_token.html.twig
+++ b/contao/templates/notification_center/file_token.html.twig
@@ -1,0 +1,13 @@
+{% if format is same as 'html' %}
+<ul>
+    {% for voucher, file in files %}
+    <li><a href="{{ notification_center_file_url(voucher) }}">{{ file.name }} ({{ file.size|format_bytes }})</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if format is same as 'text' %}
+    {% for voucher, file in files %}
+    - [{{ file.name }} ({{ file.size|format_bytes }})]({{ notification_center_file_url(voucher) }})
+    {% endfor %}
+{% endif %}

--- a/src/BulkyItem/BulkyItemStorage.php
+++ b/src/BulkyItem/BulkyItemStorage.php
@@ -102,10 +102,11 @@ class BulkyItemStorage
         }
     }
 
-    public function generatePublicUri(string $voucher): string
+    public function generatePublicUri(string $voucher, int|null $ttl = null): string
     {
         return $this->uriSigner->sign(
             $this->router->generate('nc_bulky_item_download', ['voucher' => $voucher], UrlGeneratorInterface::ABSOLUTE_URL),
+            time() + $ttl,
         );
     }
 

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -8,9 +8,12 @@ use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
+use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Terminal42\NotificationCenterBundle\Terminal42NotificationCenterBundle;
 
-class Plugin implements BundlePluginInterface
+class Plugin implements BundlePluginInterface, RoutingPluginInterface
 {
     public function getBundles(ParserInterface $parser): array
     {
@@ -19,5 +22,13 @@ class Plugin implements BundlePluginInterface
                 ->setReplace(['notification_center'])
                 ->setLoadAfter([ContaoCoreBundle::class]),
         ];
+    }
+
+    public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel)
+    {
+        return $resolver
+            ->resolve(__DIR__.'/../Controller/DownloadBulkyItemController.php', 'attribute')
+            ->load(__DIR__.'/../Controller/DownloadBulkyItemController.php')
+        ;
     }
 }

--- a/src/Controller/DownloadBulkyItemController.php
+++ b/src/Controller/DownloadBulkyItemController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
+
+#[Route('/notifications/download/{voucher}', 'nc_bulky_item_download', requirements: ['voucher' => BulkyItemStorage::VOUCHER_REGEX])]
+class DownloadBulkyItemController
+{
+    public function __construct(
+        private UriSigner $uriSigner,
+        private BulkyItemStorage $bulkyItemStorage,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $voucher): Response
+    {
+        if (!$this->uriSigner->checkRequest($request)) {
+            throw new NotFoundHttpException();
+        }
+
+        if (!$bulkyItem = $this->bulkyItemStorage->retrieve($voucher)) {
+            throw new NotFoundHttpException();
+        }
+
+        $stream = $bulkyItem->getContents();
+
+        $response = new StreamedResponse(
+            static function () use ($stream): void {
+                while (!feof($stream)) {
+                    echo fread($stream, 8192); // Read in chunks of 8 KB
+                    flush();
+                }
+                fclose($stream);
+            },
+        );
+
+        $response->headers->set('Content-Type', $bulkyItem->getMimeType());
+        $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
+
+        return $response;
+    }
+}

--- a/src/Controller/DownloadBulkyItemController.php
+++ b/src/Controller/DownloadBulkyItemController.php
@@ -43,7 +43,7 @@ class DownloadBulkyItemController
             },
         );
 
-        $response->headers->set('Content-Type', $bulkyItem->getMimeType());
+        $response->headers->set('Content-Type', 'application/octet-stream');
         $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
 
         return $response;

--- a/src/Controller/DownloadBulkyItemController.php
+++ b/src/Controller/DownloadBulkyItemController.php
@@ -16,8 +16,8 @@ use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 class DownloadBulkyItemController
 {
     public function __construct(
-        private UriSigner $uriSigner,
-        private BulkyItemStorage $bulkyItemStorage,
+        private readonly UriSigner $uriSigner,
+        private readonly BulkyItemStorage $bulkyItemStorage,
     ) {
     }
 

--- a/src/DependencyInjection/Terminal42NotificationCenterExtension.php
+++ b/src/DependencyInjection/Terminal42NotificationCenterExtension.php
@@ -61,7 +61,7 @@ class Terminal42NotificationCenterExtension extends Extension implements Configu
         }
 
         $container->findDefinition(BulkyItemStorage::class)
-            ->setArgument(1, $config['bulky_items_storage']['retention_period'])
+            ->setArgument(3, $config['bulky_items_storage']['retention_period'])
         ;
     }
 

--- a/src/EventListener/BulkyItemsTokenListener.php
+++ b/src/EventListener/BulkyItemsTokenListener.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\EventListener;
+
+use Contao\StringUtil;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemInterface;
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
+use Terminal42\NotificationCenterBundle\Event\CreateParcelEvent;
+use Terminal42\NotificationCenterBundle\Event\GetTokenDefinitionsForNotificationTypeEvent;
+use Terminal42\NotificationCenterBundle\Parcel\Parcel;
+use Terminal42\NotificationCenterBundle\Parcel\Stamp\BulkyItemsStamp;
+use Terminal42\NotificationCenterBundle\Parcel\Stamp\TokenCollectionStamp;
+use Terminal42\NotificationCenterBundle\Token\Definition\AnythingTokenDefinition;
+use Terminal42\NotificationCenterBundle\Token\Definition\Factory\TokenDefinitionFactoryInterface;
+use Terminal42\NotificationCenterBundle\Token\Definition\HtmlTokenDefinition;
+use Terminal42\NotificationCenterBundle\Token\Definition\TextTokenDefinition;
+use Terminal42\NotificationCenterBundle\Token\Token;
+use Twig\Environment;
+
+class BulkyItemsTokenListener
+{
+    public function __construct(
+        private readonly BulkyItemStorage $bulkyItemStorage,
+        private readonly TokenDefinitionFactoryInterface $tokenDefinitionFactory,
+        private readonly Environment $twig,
+    ) {
+    }
+
+    #[AsEventListener]
+    public function onGetTokenDefinitions(GetTokenDefinitionsForNotificationTypeEvent $event): void
+    {
+        $event
+            ->addTokenDefinition($this->tokenDefinitionFactory->create(AnythingTokenDefinition::class, 'file_item_html_*', 'file_item_html_*'))
+            ->addTokenDefinition($this->tokenDefinitionFactory->create(AnythingTokenDefinition::class, 'file_item_text_*', 'file_item_text_*'))
+        ;
+    }
+
+    #[AsEventListener]
+    public function onCreateParcel(CreateParcelEvent $event): void
+    {
+        if (!$event->getParcel()->hasStamp(TokenCollectionStamp::class) || !$event->getParcel()->getStamp(BulkyItemsStamp::class)) {
+            return;
+        }
+
+        $tokenCollection = $event->getParcel()->getStamp(TokenCollectionStamp::class)->tokenCollection;
+
+        foreach ($tokenCollection as $token) {
+            $items = $this->extractFileItems($token, $event->getParcel()->getStamp(BulkyItemsStamp::class));
+
+            if ([] === $items) {
+                continue;
+            }
+
+            $tokenCollection->addToken($this->createFileToken($event->getParcel(), $token, $items, 'html', HtmlTokenDefinition::class));
+            $tokenCollection->addToken($this->createFileToken($event->getParcel(), $token, $items, 'text', TextTokenDefinition::class));
+        }
+    }
+
+    /**
+     * @param array<string, BulkyItemInterface> $items
+     */
+    private function createFileToken(Parcel $parcel, Token $token, array $items, string $format, string $tokenDefinitionClass): Token
+    {
+        $content = $this->twig->render('@Contao/notification_center/file_token.html.twig', [
+            'files' => $items,
+            'parcel' => $parcel,
+            'format' => $format,
+        ]);
+
+        $tokenName = 'file_item_'.$format.'_'.$token->getName();
+
+        return $this->tokenDefinitionFactory->create($tokenDefinitionClass, $tokenName, $tokenName)
+            ->createToken($tokenName, $content)
+        ;
+    }
+
+    /**
+     * @return array<string, BulkyItemInterface>
+     */
+    private function extractFileItems(Token $token, BulkyItemsStamp $bulkyItemsStamp): array
+    {
+        $possibleVouchers = StringUtil::trimsplit(',', $token->getParserValue());
+        $items = [];
+
+        foreach ($possibleVouchers as $possibleVoucher) {
+            // Shortcut: Not a possibly bulky item voucher anyway - continue
+            if (!BulkyItemStorage::validateVoucherFormat($possibleVoucher)) {
+                continue;
+            }
+
+            if (!$bulkyItemsStamp->has($possibleVoucher)) {
+                continue;
+            }
+
+            if ($item = $this->bulkyItemStorage->retrieve($possibleVoucher)) {
+                $items[$possibleVoucher] = $item;
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/Gateway/AbstractGateway.php
+++ b/src/Gateway/AbstractGateway.php
@@ -91,7 +91,7 @@ abstract class AbstractGateway implements GatewayInterface
             return $value;
         }
 
-        $tokenCollection = $tokenCollection ?? $parcel->getStamp(TokenCollectionStamp::class)?->tokenCollection;
+        $tokenCollection ??= $parcel->getStamp(TokenCollectionStamp::class)?->tokenCollection;
 
         if (!$tokenCollection instanceof TokenCollection) {
             return $value;

--- a/src/Gateway/MailerGateway.php
+++ b/src/Gateway/MailerGateway.php
@@ -162,10 +162,7 @@ class MailerGateway extends AbstractGateway
             return $this->replaceInsertTags($languageConfig->getString('email_text'));
         }
 
-        // Otherwise convert voucher tokens to public URIs
-        $tokenCollection = $this->createTokenCollectionWithPublicBulkyItemUris($tokenCollection);
-
-        // Then replace tokens and insert tags with this collection explicitly
+        // Otherwise replace tokens and insert tags with this collection explicitly
         return $this->replaceTokensAndInsertTags($parcel, $languageConfig->getString('email_text'), $tokenCollection);
     }
 
@@ -220,11 +217,6 @@ class MailerGateway extends AbstractGateway
     {
         $languageConfig = $parcel->getStamp(LanguageConfigStamp::class)->languageConfig;
         $tokenCollection = $parcel->getStamp(TokenCollectionStamp::class)?->tokenCollection;
-
-        // Convert voucher tokens to public URIs if available
-        if ($tokenCollection instanceof TokenCollection) {
-            $tokenCollection = $this->createTokenCollectionWithPublicBulkyItemUris($tokenCollection, '<br>');
-        }
 
         $this->contaoFramework->initialize();
 

--- a/src/Twig/NotificationCenterExtension.php
+++ b/src/Twig/NotificationCenterExtension.php
@@ -4,25 +4,15 @@ declare(strict_types=1);
 
 namespace Terminal42\NotificationCenterBundle\Twig;
 
-use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class NotificationCenterExtension extends AbstractExtension
 {
-    public function __construct(private readonly BulkyItemStorage $bulkyItemStorage)
-    {
-    }
-
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('notification_center_file_url', [$this, 'fileUrl']),
+            new TwigFunction('notification_center_file_url', [NotificationCenterRuntime::class, 'fileUrl']),
         ];
-    }
-
-    public function fileUrl(string $voucher, int|null $ttl = null): string
-    {
-        return $this->bulkyItemStorage->generatePublicUri($voucher, $ttl);
     }
 }

--- a/src/Twig/NotificationCenterExtension.php
+++ b/src/Twig/NotificationCenterExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 class NotificationCenterExtension extends AbstractExtension
 {
-    public function __construct(private BulkyItemStorage $bulkyItemStorage)
+    public function __construct(private readonly BulkyItemStorage $bulkyItemStorage)
     {
     }
 

--- a/src/Twig/NotificationCenterExtension.php
+++ b/src/Twig/NotificationCenterExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Twig;
+
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class NotificationCenterExtension extends AbstractExtension
+{
+    public function __construct(private BulkyItemStorage $bulkyItemStorage)
+    {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('notification_center_file_url', [$this, 'fileUrl']),
+        ];
+    }
+
+    public function fileUrl(string $voucher, int|null $ttl = null): string
+    {
+        return $this->bulkyItemStorage->generatePublicUri($voucher, $ttl);
+    }
+}

--- a/src/Twig/NotificationCenterRuntime.php
+++ b/src/Twig/NotificationCenterRuntime.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Twig;
+
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class NotificationCenterRuntime implements RuntimeExtensionInterface
+{
+    public function __construct(private readonly BulkyItemStorage $bulkyItemStorage)
+    {
+    }
+
+    public function fileUrl(string $voucher, int|null $ttl = null): string
+    {
+        return $this->bulkyItemStorage->generatePublicUri($voucher, $ttl);
+    }
+}

--- a/tests/BulkyItem/BulkItemStorageTest.php
+++ b/tests/BulkyItem/BulkItemStorageTest.php
@@ -9,6 +9,8 @@ use Contao\CoreBundle\Filesystem\FilesystemItem;
 use Contao\CoreBundle\Filesystem\FilesystemItemIterator;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\Routing\RouterInterface;
 use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 use Terminal42\NotificationCenterBundle\BulkyItem\FileItem;
 
@@ -72,7 +74,7 @@ class BulkItemStorageTest extends TestCase
             )
         ;
 
-        $storage = new BulkyItemStorage($vfs);
+        $storage = new BulkyItemStorage($vfs, $this->createMock(RouterInterface::class), $this->createMock(UriSigner::class));
         $voucher = $storage->store($this->createFileItem());
 
         $this->assertTrue(BulkyItemStorage::validateVoucherFormat($voucher));
@@ -88,7 +90,7 @@ class BulkItemStorageTest extends TestCase
             ->willReturn(true)
         ;
 
-        $storage = new BulkyItemStorage($vfs);
+        $storage = new BulkyItemStorage($vfs, $this->createMock(RouterInterface::class), $this->createMock(UriSigner::class));
         $this->assertTrue($storage->has('a10aed4d-abe1-498f-adfc-b2e54fbbcbde'));
     }
 
@@ -118,7 +120,7 @@ class BulkItemStorageTest extends TestCase
             ->willReturn($this->createStream())
         ;
 
-        $storage = new BulkyItemStorage($vfs);
+        $storage = new BulkyItemStorage($vfs, $this->createMock(RouterInterface::class), $this->createMock(UriSigner::class));
         $item = $storage->retrieve('a10aed4d-abe1-498f-adfc-b2e54fbbcbde');
 
         $this->assertInstanceOf(FileItem::class, $item);
@@ -154,7 +156,7 @@ class BulkItemStorageTest extends TestCase
             ->with('20220101')
         ;
 
-        $storage = new BulkyItemStorage($vfs);
+        $storage = new BulkyItemStorage($vfs, $this->createMock(RouterInterface::class), $this->createMock(UriSigner::class));
         $storage->prune();
     }
 

--- a/tests/EventListener/BulkyItemsTokenListenerTest.php
+++ b/tests/EventListener/BulkyItemsTokenListenerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Test\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemInterface;
+use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
+use Terminal42\NotificationCenterBundle\Config\MessageConfig;
+use Terminal42\NotificationCenterBundle\Event\CreateParcelEvent;
+use Terminal42\NotificationCenterBundle\Event\GetTokenDefinitionsForNotificationTypeEvent;
+use Terminal42\NotificationCenterBundle\EventListener\BulkyItemsTokenListener;
+use Terminal42\NotificationCenterBundle\NotificationType\NotificationTypeInterface;
+use Terminal42\NotificationCenterBundle\Parcel\Parcel;
+use Terminal42\NotificationCenterBundle\Parcel\Stamp\BulkyItemsStamp;
+use Terminal42\NotificationCenterBundle\Parcel\Stamp\TokenCollectionStamp;
+use Terminal42\NotificationCenterBundle\Token\Definition\Factory\TokenDefinitionFactoryInterface;
+use Terminal42\NotificationCenterBundle\Token\Token;
+use Terminal42\NotificationCenterBundle\Token\TokenCollection;
+use Twig\Environment;
+
+class BulkyItemsTokenListenerTest extends TestCase
+{
+    public function testOnGetTokenDefinitions(): void
+    {
+        $tokenDefinitionFactory = $this->createMock(TokenDefinitionFactoryInterface::class);
+        $tokenDefinitionFactory
+            ->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnCallback(static fn (string $definitionClass, string $tokenName, string $translationKey) => new $definitionClass($tokenName, $translationKey))
+        ;
+
+        $event = new GetTokenDefinitionsForNotificationTypeEvent($this->createMock(NotificationTypeInterface::class));
+        $listener = new BulkyItemsTokenListener(
+            $this->createMock(BulkyItemStorage::class),
+            $tokenDefinitionFactory,
+            $this->createMock(Environment::class),
+        );
+
+        $listener->onGetTokenDefinitions($event);
+
+        $this->assertSame(['file_item_html_*', 'file_item_text_*'], array_keys($event->getTokenDefinitions()));
+    }
+
+    public function testOnCreateParcelSkipsIfStampsAreMissing(): void
+    {
+        $parcel = new Parcel(MessageConfig::fromArray([]));
+        $event = new CreateParcelEvent($parcel);
+
+        $listener = new BulkyItemsTokenListener(
+            $this->createMock(BulkyItemStorage::class),
+            $this->createMock(TokenDefinitionFactoryInterface::class),
+            $this->createMock(Environment::class),
+        );
+
+        $listener->onCreateParcel($event);
+
+        $this->addToAssertionCount(1); // Ensure no exceptions or errors
+    }
+
+    public function testOnCreateParcelProcessesTokens(): void
+    {
+        $bulkyItemStorage = $this->createMock(BulkyItemStorage::class);
+        $bulkyItemStorage
+            ->method('retrieve')
+            ->willReturn($this->createMock(BulkyItemInterface::class))
+        ;
+
+        $tokenDefinitionFactory = $this->createMock(TokenDefinitionFactoryInterface::class);
+        $tokenDefinitionFactory
+            ->method('create')
+            ->willReturnCallback(static fn (string $definitionClass, string $tokenName, string $translationKey) => new $definitionClass($tokenName, $translationKey))
+        ;
+
+        $twig = $this->createMock(Environment::class);
+        $twig
+            ->method('render')
+            ->willReturnCallback(
+                function (string $template, array $context) {
+                    $this->assertSame('@Contao/notification_center/file_token.html.twig', $template);
+
+                    return match ($context['format']) {
+                        'html' => 'rendered_html_content',
+                        'text' => 'rendered_text_content',
+                        default => $this->fail('Invalid format!'),
+                    };
+                },
+            )
+        ;
+
+        $tokenCollection = new TokenCollection();
+        $tokenCollection->addToken(new Token('form_upload', '20221228/a10aed4d-abe1-498f-adfc-b2e54fbbcbde', '20221228/a10aed4d-abe1-498f-adfc-b2e54fbbcbde'));
+
+        $parcel = new Parcel(MessageConfig::fromArray([]));
+        $parcel = $parcel->withStamp(new TokenCollectionStamp($tokenCollection));
+        $parcel = $parcel->withStamp(new BulkyItemsStamp(['20221228/a10aed4d-abe1-498f-adfc-b2e54fbbcbde']));
+        $event = new CreateParcelEvent($parcel);
+
+        $listener = new BulkyItemsTokenListener(
+            $bulkyItemStorage,
+            $tokenDefinitionFactory,
+            $twig,
+        );
+
+        $listener->onCreateParcel($event);
+
+        $tokenCollection = $event->getParcel()->getStamp(TokenCollectionStamp::class)?->tokenCollection;
+        $this->assertInstanceOf(TokenCollection::class, $tokenCollection);
+        $this->assertTrue($tokenCollection->has('file_item_html_form_upload'));
+        $this->assertTrue($tokenCollection->has('file_item_text_form_upload'));
+        $this->assertSame('rendered_html_content', $tokenCollection->getByName('file_item_html_form_upload')->getParserValue());
+        $this->assertSame('rendered_text_content', $tokenCollection->getByName('file_item_text_form_upload')->getParserValue());
+    }
+}

--- a/tests/Gateway/MailerGatewayTest.php
+++ b/tests/Gateway/MailerGatewayTest.php
@@ -15,8 +15,10 @@ use Contao\TestCase\ContaoTestCase;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\UriSigner;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\RouterInterface;
 use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 use Terminal42\NotificationCenterBundle\Config\LanguageConfig;
 use Terminal42\NotificationCenterBundle\Config\MessageConfig;
@@ -88,7 +90,7 @@ class MailerGatewayTest extends ContaoTestCase
             $mailer,
         );
         $container = new Container();
-        $container->set(AbstractGateway::SERVICE_NAME_BULKY_ITEM_STORAGE, new BulkyItemStorage($vfsCollection->get('bulky_item')));
+        $container->set(AbstractGateway::SERVICE_NAME_BULKY_ITEM_STORAGE, new BulkyItemStorage($vfsCollection->get('bulky_item'), $this->createMock(RouterInterface::class), $this->createMock(UriSigner::class)));
         $container->set(AbstractGateway::SERVICE_NAME_SIMPLE_TOKEN_PARSER, new SimpleTokenParser(new ExpressionLanguage()));
         $gateway->setContainer($container);
 


### PR DESCRIPTION
This implements a general listener for all bulky items.

For example, if you have a `##form_upload##` field with an associated bulky items voucher, you will now automatically also get a `##file_item_html_form_upload##` and `##file_item_text_form_upload##` token.
You notice, the format is: `file_item_<format>_<tokenName>`.

The contents of those are defined by the new `@Contao/notification_center/file_token.html.twig` template which you can adjust. By default it will generate the following outputs:

For `text`:
```
- [test.png (10,9 KiB)](https://example.com/notifications/download/20241119/58161a5d-9e87-4fc8-839b-5ccfb1fa2aca?_hash=foobar)
- [test__2.png (10,9 KiB)](https://example.com/notifications/download/20241119/654bd791-3ff7-4480-8f75-801387178d16?_hash=foobar)
```

For `html`:

```
<ul>
  <li><a href="https://example.com/notifications/download/20241119/58161a5d-9e87-4fc8-839b-5ccfb1fa2aca?_hash=foobar">test.png (10,9 KiB)</a></li>
  <li><a href="https://example.com/notifications/download/20241119/654bd791-3ff7-4480-8f75-801387178d16?_hash=foobar">test__2.png (10,9 KiB)</a></li>
</ul>
```

You may adjust the `@Contao/notification_center/file_token.html.twig` according to your needs. You get the file items, the format but also the entire `Parcel` as template context in case you need to do anything complex.

The Twig template uses a `notification_center_file_url()` method that generates the URL to the file. It takes an optional 2nd parameter for `$ttl` in case you want to limit the downloads to a certain expiry date which I don't think is a requirement by default.