### PR TITLE
Add the missing `MailerTransportMigration` service definition

### DIFF
--- a/config/migrations.php
+++ b/config/migrations.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Terminal42\NotificationCenterBundle\Migration\EmailGatewayMigration;
+use Terminal42\NotificationCenterBundle\Migration\MailerTransportMigration;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
     $services->defaults()->autoconfigure();
 
     $services->set(EmailGatewayMigration::class)
+        ->args([
+            service('database_connection'),
+        ])
+    ;
+
+    $services->set(MailerTransportMigration::class)
         ->args([
             service('database_connection'),
         ])


### PR DESCRIPTION
This adds the missing service definition for the `MailerTransportMigration` added in #344, similar to #333.