### PR TITLE
Added Contao 4.13 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Require Contao version for tests
               run: composer require contao/core-bundle:${{ matrix.contao }}.* --dev --no-update
 
-            # Remove this once https://github.com/contao/contao/pull/7751 is merged
+            # Remove this once https://github.com/contao/contao/pull/7751 is merged and Contao 4.13.51 is released
             - name: Require TestCase version for tests
               run: composer require contao/test-case:${{ matrix.contao }}.* --dev --no-update
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,13 @@ jobs:
         uses: 'terminal42/contao-build-tools/.github/workflows/build-tools.yml@main'
 
     tests:
-        name: Unit tests
+        name: Unit tests (PHP ${{ matrix.php }} / Contao ${{ matrix.contao }})
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.1', '8.2', '8.3' ]
+                php: [ '8.1', '8.2', '8.3', '8.4' ]
+                contao: [ '4.13', '5.3', '5.4' ]
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -26,6 +27,13 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@v3
+
+            - name: Require Contao version for tests
+              run: composer require contao/core-bundle:${{ matrix.contao }}.* --dev --no-update
+
+            # Remove this once https://github.com/contao/contao/pull/7751 is merged
+            - name: Require TestCase version for tests
+              run: composer require contao/test-case:${{ matrix.contao }}.* --dev --no-update
 
             - name: Install the dependencies
               run: |

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,0 +1,10 @@
+<?php
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+return (new Configuration())
+    ->ignoreErrorsOnPackage('symfony/translation', [ErrorType::SHADOW_DEPENDENCY])
+    ->ignoreErrorsOnPackage('contao/newsletter-bundle', [ErrorType::DEV_DEPENDENCY_IN_PROD])
+    ->ignoreUnknownClasses([Symfony\Component\HttpKernel\UriSigner::class, Contao\ModulePassword::class])
+;

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "doctrine/orm": "^2.19",
         "knplabs/knp-menu": "^3.1",
         "psr/container": "^1.0 || ^2.0",
+        "psr/log": "^2.0 || ^3.0",
         "ramsey/collection": "^1.2",
         "soundasleep/html2text": "^2.0",
         "symfony/asset": "^5.4 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -54,8 +54,8 @@
     },
     "require-dev": {
         "contao/manager-plugin": "^2.0",
-        "contao/newsletter-bundle": "^5.0",
-        "contao/test-case": "^5.3",
+        "contao/newsletter-bundle": "^4.13 || ^5.0",
+        "contao/test-case": "^4.13 || ^5.3",
         "league/flysystem-memory": "^3.25",
         "phpunit/phpunit": "^9.6",
         "symfony/expression-language": "^5.4 || ^6.0 || ^7.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
 parameters:
 	excludePaths:
 		- src/Legacy/LostPasswordModule.php
+	ignoreErrors:
+		- '#Symfony\\Component\\HttpKernel\\UriSigner#'

--- a/src/BulkyItem/BulkyItemStorage.php
+++ b/src/BulkyItem/BulkyItemStorage.php
@@ -7,7 +7,8 @@ namespace Terminal42\NotificationCenterBundle\BulkyItem;
 use Contao\CoreBundle\Filesystem\ExtraMetadata;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemException;
 use Contao\CoreBundle\Filesystem\VirtualFilesystemInterface;
-use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSigner as HttpFoundationUriSigner;
+use Symfony\Component\HttpKernel\UriSigner as HttpKernelUriSigner;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Uid\Uuid;
@@ -19,7 +20,7 @@ class BulkyItemStorage
     public function __construct(
         private readonly VirtualFilesystemInterface $filesystem,
         private readonly RouterInterface $router,
-        private readonly UriSigner $uriSigner,
+        private readonly HttpFoundationUriSigner|HttpKernelUriSigner $uriSigner,
         private readonly int $retentionPeriodInDays = 7,
     ) {
     }

--- a/src/Controller/DownloadBulkyItemController.php
+++ b/src/Controller/DownloadBulkyItemController.php
@@ -7,8 +7,9 @@ namespace Terminal42\NotificationCenterBundle\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-use Symfony\Component\HttpFoundation\UriSigner;
+use Symfony\Component\HttpFoundation\UriSigner as HttpFoundationUriSigner;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\UriSigner as HttpKernelUriSigner;
 use Symfony\Component\Routing\Attribute\Route;
 use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 
@@ -16,7 +17,7 @@ use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 class DownloadBulkyItemController
 {
     public function __construct(
-        private readonly UriSigner $uriSigner,
+        private readonly HttpFoundationUriSigner|HttpKernelUriSigner $uriSigner,
         private readonly BulkyItemStorage $bulkyItemStorage,
     ) {
     }


### PR DESCRIPTION
This adds a test matrix for Contao versions and fixes various issues found with Contao 4.13 / Symfony 5.4.

Failing tests on Contao 5.3 / PHP 8.4 should be fixed by https://github.com/contao/contao/pull/7749