### PR TITLE
Make sure mailerTransport can be NULL

### DIFF
--- a/src/Migration/MailerTransportMigration.php
+++ b/src/Migration/MailerTransportMigration.php
@@ -33,7 +33,7 @@ class MailerTransportMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
-        $this->connection->executeStatement("ALTER TABLE tl_nc_gateway CHANGE mailerTransport mailterTransport varchar(64) DEFAULT NULL");
+        $this->connection->executeStatement("ALTER TABLE tl_nc_gateway CHANGE mailerTransport mailerTransport varchar(64) DEFAULT NULL");
         $this->connection->executeStatement("UPDATE tl_nc_gateway SET mailerTransport = NULL WHERE mailerTransport = ''");
 
         return $this->createResult(true);

--- a/src/Migration/MailerTransportMigration.php
+++ b/src/Migration/MailerTransportMigration.php
@@ -33,6 +33,7 @@ class MailerTransportMigration extends AbstractMigration
 
     public function run(): MigrationResult
     {
+        $this->connection->executeStatement("ALTER TABLE tl_nc_gateway CHANGE mailerTransport mailterTransport varchar(64) DEFAULT NULL");
         $this->connection->executeStatement("UPDATE tl_nc_gateway SET mailerTransport = NULL WHERE mailerTransport = ''");
 
         return $this->createResult(true);


### PR DESCRIPTION
While updating from Contao 4.13 and Notification Center 1.*, I got the following error because the field appears to be non-nullable in version 1

> SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'mailerTransport' cannot be null