### PR TITLE
Remove CI setup for contao/test-case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
             - name: Require Contao version for tests
               run: composer require contao/core-bundle:${{ matrix.contao }}.* --dev --no-update
 
-            # Remove this once https://github.com/contao/contao/pull/7751 is merged and Contao 4.13.51 is released
-            - name: Require TestCase version for tests
-              run: composer require contao/test-case:${{ matrix.contao }}.* --dev --no-update
-
             - name: Install the dependencies
               run: |
                   composer install --no-interaction --no-progress --no-plugins


### PR DESCRIPTION
https://github.com/contao/contao/pull/7751 has been merged, but we should still wait until released.