### PR TITLE
Added a simple token migration for dashes

### DIFF
--- a/config/migrations.php
+++ b/config/migrations.php
@@ -6,6 +6,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Terminal42\NotificationCenterBundle\Migration\EmailGatewayMigration;
 use Terminal42\NotificationCenterBundle\Migration\MailerTransportMigration;
+use Terminal42\NotificationCenterBundle\Migration\SimpleTokenMigration;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -18,6 +19,12 @@ return static function (ContainerConfigurator $container): void {
     ;
 
     $services->set(MailerTransportMigration::class)
+        ->args([
+            service('database_connection'),
+        ])
+    ;
+
+    $services->set(SimpleTokenMigration::class)
         ->args([
             service('database_connection'),
         ])

--- a/src/Migration/SimpleTokenMigration.php
+++ b/src/Migration/SimpleTokenMigration.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Migration;
+
+use Contao\CoreBundle\Migration\AbstractMigration;
+use Contao\CoreBundle\Migration\MigrationResult;
+use Doctrine\DBAL\Connection;
+
+class SimpleTokenMigration extends AbstractMigration
+{
+    private const REGEX = '/##([a-zA-Z0-9_]+-[a-zA-Z0-9_-]*)##/';
+
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function shouldRun(): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+
+        if (!$schemaManager->tablesExist(['tl_nc_language'])) {
+            return false;
+        }
+
+        return [] !== $this->getRowsToUpdate();
+    }
+
+    public function run(): MigrationResult
+    {
+        foreach ($this->getRowsToUpdate() as $rowId => $columns) {
+            $rows = $this->connection->fetchAssociative('SELECT '.implode(',', $columns).' FROM tl_nc_language WHERE id=?', [$rowId]);
+            $set = [];
+
+            foreach ($rows as $column => $value) {
+                $set[$column] = preg_replace_callback(
+                    self::REGEX,
+                    static fn ($matches) => '##'.str_replace('-', '_', $matches[1]).'##',
+                    $value,
+                );
+            }
+
+            $this->connection->update('tl_nc_language', $set, ['id' => $rowId]);
+        }
+
+        return $this->createResult(true);
+    }
+
+    private function getRowsToUpdate(): array
+    {
+        $rowsToUpdate = [];
+
+        foreach ($this->connection->fetchAllAssociative('SELECT * FROM tl_nc_language') as $row) {
+            foreach ($row as $column => $value) {
+                if (!\is_string($value)) {
+                    continue;
+                }
+
+                if (preg_match(self::REGEX, $value)) {
+                    $rowsToUpdate[$row['id']][] = $this->connection->quoteIdentifier($column);
+                }
+            }
+        }
+
+        return $rowsToUpdate;
+    }
+}


### PR DESCRIPTION
This automatically migrates simple tokens using `-` to using `_`. The alternative would be to allow both, `-` as well as `_` but I'm still not sure this is a good idea from a UX perspective...

Background: Contao's SimpleTokenParser (or Symfony Expression Language) cannot handle tokens with `-`. Thus, you cannot use them in `{if ` conditions. Hence, there are 2 solutions:

1. Normalize all tokens from `-` to `_` and migrate existing data (current solution with this PR)
2. Automatically generate normalized tokens on top of e.g. `##e-mail##` so that you can write `{if e_mail ...}##e-mail##{endif}`

So 1. would have consistent tokens everywhere but force users to re-think somehow. With the migration in this PR it would be complete, though. 2. would have inconsistent tokens but maybe this is better?