### PR TITLE
Normalize token names but keep original ones

### DIFF
--- a/src/Token/TokenCollection.php
+++ b/src/Token/TokenCollection.php
@@ -58,9 +58,12 @@ class TokenCollection extends AbstractCollection
     public function forSimpleTokenParser(): array
     {
         $data = [];
+        $normalized = [];
 
         /** @var Token $token */
         foreach ($this as $token) {
+            $data[$token->getName()] = $token->getParserValue();
+
             // Replace everything that's not allowed from the beginning of a string (PHP
             // variables cannot start with numbers for example)
             $tokenName = preg_replace_callback(
@@ -84,7 +87,15 @@ class TokenCollection extends AbstractCollection
                 (string) $tokenName,
             );
 
-            $data[$tokenName] = $token->getParserValue();
+            if ($tokenName !== $token->getName()) {
+                $normalized[$tokenName] = $token->getParserValue();
+            }
+        }
+
+        foreach ($normalized as $tokenName => $value) {
+            if (!isset($data[$tokenName])) {
+                $data[$tokenName] = $value;
+            }
         }
 
         return $data;

--- a/tests/Token/TokenCollectionTest.php
+++ b/tests/Token/TokenCollectionTest.php
@@ -103,12 +103,16 @@ class TokenCollectionTest extends TestCase
     {
         $tokenCollection = new TokenCollection();
         $tokenCollection->add(Token::fromValue('invalid-because-of-dashes', 'foobar'));
+        $tokenCollection->add(Token::fromValue('invalid_because_of_dashes', 'foobar2'));
         $tokenCollection->add(Token::fromValue('123invalid_because_of_numbers_at_the_start', 'foobar'));
         $tokenCollection->add(Token::fromValue('1234-', 'foobar'));
 
         $this->assertSame(
             [
-                'invalid_because_of_dashes' => 'foobar',
+                'invalid-because-of-dashes' => 'foobar',
+                'invalid_because_of_dashes' => 'foobar2',
+                '123invalid_because_of_numbers_at_the_start' => 'foobar',
+                '1234-' => 'foobar',
                 '___invalid_because_of_numbers_at_the_start' => 'foobar',
                 '_____' => 'foobar',
             ],
@@ -121,6 +125,7 @@ class TokenCollectionTest extends TestCase
         $this->assertSame(
             [
                 'invalid-because-of-dashes' => 'foobar',
+                'invalid_because_of_dashes' => 'foobar2',
                 '123invalid_because_of_numbers_at_the_start' => 'foobar',
                 '1234-' => 'foobar',
             ],


### PR DESCRIPTION
Alternative to https://github.com/terminal42/contao-notification_center/pull/390.

In this PR we would not force the users to write `##form_e_mail##`, they could still use `##form_e-mail##`. 
However, they still cannot use `{if form_e-mail == ...}` but will have to use `{if form_e_mail == ...}` because again, tokens in the expression language are not allowed to contain dashes.