### PR TITLE
Store only file references instead of base64 encoded filecontent in database

### DIFF
--- a/src/Gateway/MailerGateway.php
+++ b/src/Gateway/MailerGateway.php
@@ -11,8 +11,10 @@ use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\CoreBundle\Util\LocaleUtil;
 use Contao\FrontendTemplate;
 use Contao\StringUtil;
+use Contao\System;
 use Contao\Validator;
 use Soundasleep\Html2Text;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Uid\Uuid;
@@ -179,8 +181,12 @@ class MailerGateway extends AbstractGateway
             $item = $this->getBulkyItemStorage()?->retrieve($voucher);
 
             if ($item instanceof FileItem) {
-                $email->attach(
-                    $item->getContents(),
+                $email->attachFromPath(
+                    Path::join(
+                        System::getContainer()->getParameter('kernel.project_dir'),
+                        'var/nc_bulky_items',
+                        $voucher
+                    ),
                     $item->getName(),
                     $item->getMimeType(),
                 );
@@ -190,8 +196,16 @@ class MailerGateway extends AbstractGateway
         // Embedded images
         foreach ($emailStamp->getEmbeddedImageVouchers() as $voucher) {
             $item = $this->getBulkyItemStorage()?->retrieve($voucher);
+
             if ($item instanceof FileItem) {
-                $email->attach($item->getContents(), $this->encodeVoucherForContentId($voucher));
+                $email->attachFromPath(
+                    Path::join(
+                        System::getContainer()->getParameter('kernel.project_dir'),
+                        'var/nc_bulky_items',
+                        $voucher
+                    ),
+                    $this->encodeVoucherForContentId($voucher)
+                );
             }
         }
 


### PR DESCRIPTION
Emails that are temporarily stored in the database for asynchronous sending currently contain the filecontent of all attachments Base64-encoded. This leads to large queries and can lead to errors with large attachments.

The MailerGateway class has been modified so that in this case only a reference to temporary files are stored in the database, which are already created via the BulkyItemStorage class in the 'var/nc_bulky_items' folder.
