### PR TITLE
Added support for asynchronous receipts

### DIFF
--- a/config/listeners.php
+++ b/config/listeners.php
@@ -23,6 +23,7 @@ use Terminal42\NotificationCenterBundle\EventListener\DbafsMetadataListener;
 use Terminal42\NotificationCenterBundle\EventListener\DisableDeliveryListener;
 use Terminal42\NotificationCenterBundle\EventListener\DoctrineSchemaListener;
 use Terminal42\NotificationCenterBundle\EventListener\LogUnsuccessfulDeliveries;
+use Terminal42\NotificationCenterBundle\EventListener\MailerAsynchronousReceiptUpdateListener;
 use Terminal42\NotificationCenterBundle\EventListener\MailerAttachmentsListener;
 use Terminal42\NotificationCenterBundle\EventListener\NotificationCenterProListener;
 use Terminal42\NotificationCenterBundle\EventListener\NotificationTypeForModuleListener;
@@ -155,6 +156,12 @@ return static function (ContainerConfigurator $container): void {
     $services->set(MailerAttachmentsListener::class)
         ->args([
             service(BulkyItemStorage::class),
+        ])
+    ;
+
+    $services->set(MailerAsynchronousReceiptUpdateListener::class)
+        ->args([
+            service(NotificationCenter::class),
         ])
     ;
 };

--- a/src/Event/AsynchronousReceiptEvent.php
+++ b/src/Event/AsynchronousReceiptEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Terminal42\NotificationCenterBundle\Receipt\AsynchronousReceipt;
+
+class AsynchronousReceiptEvent extends Event
+{
+    public function __construct(public readonly AsynchronousReceipt $receipt)
+    {
+    }
+}

--- a/src/EventListener/MailerAsynchronousReceiptUpdateListener.php
+++ b/src/EventListener/MailerAsynchronousReceiptUpdateListener.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Mailer\Event\FailedMessageEvent;
+use Symfony\Component\Mailer\Event\SentMessageEvent;
+use Symfony\Component\Mime\Email;
+use Terminal42\NotificationCenterBundle\Gateway\MailerGateway;
+use Terminal42\NotificationCenterBundle\NotificationCenter;
+use Terminal42\NotificationCenterBundle\Receipt\AsynchronousReceipt;
+
+class MailerAsynchronousReceiptUpdateListener
+{
+    public function __construct(private readonly NotificationCenter $notificationCenter)
+    {
+    }
+
+    #[AsEventListener]
+    public function onSentMessage(SentMessageEvent $event): void
+    {
+        $email = $event->getMessage()->getOriginalMessage();
+
+        if (!$email instanceof Email) {
+            return;
+        }
+
+        $this->handleEmail($email);
+    }
+
+    #[AsEventListener]
+    public function onFailedMessage(FailedMessageEvent $event): void
+    {
+        $email = $event->getMessage();
+
+        if (!$email instanceof Email) {
+            return;
+        }
+
+        $this->handleEmail($email, $event->getError());
+    }
+
+    private function handleEmail(Email $email, \Throwable|null $error = null): void
+    {
+        $messageId = $email->getHeaders()->get(MailerGateway::MESSAGE_IDENTIFIER_HEADER)?->getBodyAsString();
+        $email->getHeaders()->remove(MailerGateway::MESSAGE_IDENTIFIER_HEADER);
+
+        if (!$messageId) {
+            return;
+        }
+
+        $receipt = $error
+            ? AsynchronousReceipt::createForUnsuccessfulDelivery($messageId, $error)
+            : AsynchronousReceipt::createForSuccessfulDelivery($messageId);
+
+        $this->notificationCenter->informAboutAsynchronousReceipt($receipt);
+    }
+}

--- a/src/NotificationCenter.php
+++ b/src/NotificationCenter.php
@@ -14,6 +14,7 @@ use Symfony\Component\Translation\LocaleSwitcher;
 use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
 use Terminal42\NotificationCenterBundle\Config\ConfigLoader;
 use Terminal42\NotificationCenterBundle\Config\NotificationConfig;
+use Terminal42\NotificationCenterBundle\Event\AsynchronousReceiptEvent;
 use Terminal42\NotificationCenterBundle\Event\CreateParcelEvent;
 use Terminal42\NotificationCenterBundle\Event\GetTokenDefinitionClassesForContextEvent;
 use Terminal42\NotificationCenterBundle\Event\GetTokenDefinitionsForNotificationTypeEvent;
@@ -34,6 +35,7 @@ use Terminal42\NotificationCenterBundle\Parcel\Stamp\LocaleStamp;
 use Terminal42\NotificationCenterBundle\Parcel\Stamp\NotificationConfigStamp;
 use Terminal42\NotificationCenterBundle\Parcel\Stamp\TokenCollectionStamp;
 use Terminal42\NotificationCenterBundle\Parcel\StampCollection;
+use Terminal42\NotificationCenterBundle\Receipt\AsynchronousReceipt;
 use Terminal42\NotificationCenterBundle\Receipt\Receipt;
 use Terminal42\NotificationCenterBundle\Receipt\ReceiptCollection;
 use Terminal42\NotificationCenterBundle\Token\Definition\TokenDefinitionInterface;
@@ -399,5 +401,10 @@ class NotificationCenter
         }
 
         return $stamps->with(new TokenCollectionStamp($tokens));
+    }
+
+    public function informAboutAsynchronousReceipt(AsynchronousReceipt $receipt): void
+    {
+        $this->eventDispatcher->dispatch(new AsynchronousReceiptEvent($receipt));
     }
 }

--- a/src/Parcel/Stamp/AsynchronousDeliveryStamp.php
+++ b/src/Parcel/Stamp/AsynchronousDeliveryStamp.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Parcel\Stamp;
+
+class AsynchronousDeliveryStamp implements StampInterface
+{
+    public function __construct(public string $identifier)
+    {
+        $length = \strlen($this->identifier);
+        if ($length < 1 || $length > 64) {
+            throw new \InvalidArgumentException('The identifier length must be between 1 and 64 characters.');
+        }
+    }
+
+    public function toArray(): array
+    {
+        return ['identifier' => $this->identifier];
+    }
+
+    public static function fromArray(array $data): StampInterface
+    {
+        return new self($data['identifier']);
+    }
+
+    public static function createWithRandomId(): self
+    {
+        return new self(bin2hex(random_bytes(32)));
+    }
+}

--- a/src/Parcel/Stamp/AsynchronousDeliveryStamp.php
+++ b/src/Parcel/Stamp/AsynchronousDeliveryStamp.php
@@ -19,7 +19,7 @@ class AsynchronousDeliveryStamp implements StampInterface
         return ['identifier' => $this->identifier];
     }
 
-    public static function fromArray(array $data): StampInterface
+    public static function fromArray(array $data): self
     {
         return new self($data['identifier']);
     }

--- a/src/Receipt/AsynchronousReceipt.php
+++ b/src/Receipt/AsynchronousReceipt.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Receipt;
+
+final class AsynchronousReceipt
+{
+    private \Throwable|null $exception = null;
+
+    private function __construct(
+        private readonly string $identifier,
+        private readonly bool $wasDelivered,
+    ) {
+        $length = \strlen($this->identifier);
+        if ($length < 1 || $length > 64) {
+            throw new \InvalidArgumentException('The identifier length must be between 1 and 64 characters.');
+        }
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function wasDelivered(): bool
+    {
+        return $this->wasDelivered;
+    }
+
+    public function getException(): \Throwable|null
+    {
+        return $this->exception;
+    }
+
+    public static function createForSuccessfulDelivery(string $identifier): self
+    {
+        return new self($identifier, true);
+    }
+
+    public static function createForUnsuccessfulDelivery(string $identifier, \Throwable $exception): self
+    {
+        $receipt = new self($identifier, false);
+        $receipt->exception = $exception;
+
+        return $receipt;
+    }
+}

--- a/tests/EventListener/MailerAsynchronousReceiptUpdateListenerTest.php
+++ b/tests/EventListener/MailerAsynchronousReceiptUpdateListenerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Test\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Event\FailedMessageEvent;
+use Symfony\Component\Mailer\Event\SentMessageEvent;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Message;
+use Terminal42\NotificationCenterBundle\EventListener\MailerAsynchronousReceiptUpdateListener;
+use Terminal42\NotificationCenterBundle\Gateway\MailerGateway;
+use Terminal42\NotificationCenterBundle\NotificationCenter;
+use Terminal42\NotificationCenterBundle\Receipt\AsynchronousReceipt;
+
+class MailerAsynchronousReceiptUpdateListenerTest extends TestCase
+{
+    public function testOnSentMessageWithValidEmail(): void
+    {
+        $notificationCenter = $this->createMock(NotificationCenter::class);
+        $listener = new MailerAsynchronousReceiptUpdateListener($notificationCenter);
+
+        $email = new Email();
+        $identifier = 'test-identifier';
+        $email->getHeaders()->addTextHeader(MailerGateway::MESSAGE_IDENTIFIER_HEADER, $identifier);
+
+        $sentMessage = $this->createMock(SentMessage::class);
+        $sentMessage
+            ->expects($this->once())
+            ->method('getOriginalMessage')
+            ->willReturn($email)
+        ;
+
+        $event = new SentMessageEvent($sentMessage);
+
+        $notificationCenter
+            ->expects($this->once())
+            ->method('informAboutAsynchronousReceipt')
+            ->with($this->callback(static fn (AsynchronousReceipt $receipt) => $receipt->getIdentifier() === $identifier && true === $receipt->wasDelivered()))
+        ;
+
+        $listener->onSentMessage($event);
+    }
+
+    public function testOnFailedMessage(): void
+    {
+        $notificationCenter = $this->createMock(NotificationCenter::class);
+        $listener = new MailerAsynchronousReceiptUpdateListener($notificationCenter);
+
+        $email = new Email();
+        $identifier = 'fail-identifier';
+        $email->getHeaders()->addTextHeader(MailerGateway::MESSAGE_IDENTIFIER_HEADER, $identifier);
+
+        $exception = new \Exception('Delivery failed');
+        $event = new FailedMessageEvent($email, $exception);
+
+        $notificationCenter
+            ->expects($this->once())
+            ->method('informAboutAsynchronousReceipt')
+            ->with($this->callback(static fn (AsynchronousReceipt $receipt) => $receipt->getIdentifier() === $identifier
+                    && false === $receipt->wasDelivered()
+                    && $exception === $receipt->getException(),
+            ))
+        ;
+
+        $listener->onFailedMessage($event);
+    }
+
+    public function testIgnoresNonEmailMessages(): void
+    {
+        $notificationCenter = $this->createMock(NotificationCenter::class);
+        $notificationCenter
+            ->expects($this->never())
+            ->method('informAboutAsynchronousReceipt')
+        ;
+
+        $listener = new MailerAsynchronousReceiptUpdateListener($notificationCenter);
+
+        $sentMessage = $this->createMock(SentMessage::class);
+        $sentMessage
+            ->expects($this->once())
+            ->method('getOriginalMessage')
+            ->willReturn(new Message())
+        ;
+
+        $event = new SentMessageEvent($sentMessage);
+        $listener->onSentMessage($event);
+    }
+
+    public function testSkipsWhenIdentifierHeaderMissing(): void
+    {
+        $notificationCenter = $this->createMock(NotificationCenter::class);
+        $notificationCenter
+            ->expects($this->never())
+            ->method('informAboutAsynchronousReceipt')
+        ;
+
+        $listener = new MailerAsynchronousReceiptUpdateListener($notificationCenter);
+
+        $email = new Email(); // No header added
+
+        $sentMessage = $this->createMock(SentMessage::class);
+        $sentMessage
+            ->method('getOriginalMessage')
+            ->willReturn($email)
+        ;
+        $event = new SentMessageEvent($sentMessage);
+
+        $listener->onSentMessage($event);
+    }
+}

--- a/tests/EventListener/MailerAsynchronousReceiptUpdateListenerTest.php
+++ b/tests/EventListener/MailerAsynchronousReceiptUpdateListenerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Terminal42\NotificationCenterBundle\Test\EventListener;
 
+use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Event\FailedMessageEvent;
 use Symfony\Component\Mailer\Event\SentMessageEvent;
@@ -17,6 +18,13 @@ use Terminal42\NotificationCenterBundle\Receipt\AsynchronousReceipt;
 
 class MailerAsynchronousReceiptUpdateListenerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (version_compare(InstalledVersions::getVersion('contao/core-bundle'), '5.0.0', '<')) {
+            $this->markTestSkipped('Asynchronous mailer updates are only supported as of Contao 5. In Contao 4.13 they are always synchronous anyway.');
+        }
+    }
+
     public function testOnSentMessageWithValidEmail(): void
     {
         $notificationCenter = $this->createMock(NotificationCenter::class);

--- a/tests/Parcel/Stamp/AsynchronousDeliveryStampTest.php
+++ b/tests/Parcel/Stamp/AsynchronousDeliveryStampTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Terminal42\NotificationCenterBundle\Test\Parcel\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Terminal42\NotificationCenterBundle\Parcel\Stamp\AsynchronousDeliveryStamp;
+
+class AsynchronousDeliveryStampTest extends TestCase
+{
+    public function testConstructorWithValidIdentifier(): void
+    {
+        $stamp = new AsynchronousDeliveryStamp('valid_identifier');
+        $this->assertInstanceOf(AsynchronousDeliveryStamp::class, $stamp);
+        $this->assertSame('valid_identifier', $stamp->identifier);
+    }
+
+    public function testConstructorWithInvalidIdentifier(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The identifier length must not exceed 64 characters.');
+
+        $longIdentifier = str_repeat('a', 65); // 65 characters
+        new AsynchronousDeliveryStamp($longIdentifier);
+    }
+
+    public function testToArray(): void
+    {
+        $stamp = new AsynchronousDeliveryStamp('test_id');
+        $this->assertSame(['identifier' => 'test_id'], $stamp->toArray());
+    }
+
+    public function testFromArray(): void
+    {
+        $data = ['identifier' => 'array_id'];
+        $stamp = AsynchronousDeliveryStamp::fromArray($data);
+        $this->assertInstanceOf(AsynchronousDeliveryStamp::class, $stamp);
+        $this->assertSame('array_id', $stamp->identifier);
+    }
+
+    public function testCreateWithRandomId(): void
+    {
+        $stamp = AsynchronousDeliveryStamp::createWithRandomId();
+        $this->assertInstanceOf(AsynchronousDeliveryStamp::class, $stamp);
+        $this->assertSame(64, \strlen($stamp->identifier));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $stamp->identifier);
+    }
+}

--- a/tests/Parcel/Stamp/AsynchronousDeliveryStampTest.php
+++ b/tests/Parcel/Stamp/AsynchronousDeliveryStampTest.php
@@ -18,7 +18,7 @@ class AsynchronousDeliveryStampTest extends TestCase
     public function testConstructorWithInvalidIdentifier(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The identifier length must not exceed 64 characters.');
+        $this->expectExceptionMessage('The identifier length must be between 1 and 64 characters.');
 
         $longIdentifier = str_repeat('a', 65); // 65 characters
         new AsynchronousDeliveryStamp($longIdentifier);

--- a/tests/Parcel/Stamp/AsynchronousDeliveryStampTest.php
+++ b/tests/Parcel/Stamp/AsynchronousDeliveryStampTest.php
@@ -12,7 +12,6 @@ class AsynchronousDeliveryStampTest extends TestCase
     public function testConstructorWithValidIdentifier(): void
     {
         $stamp = new AsynchronousDeliveryStamp('valid_identifier');
-        $this->assertInstanceOf(AsynchronousDeliveryStamp::class, $stamp);
         $this->assertSame('valid_identifier', $stamp->identifier);
     }
 
@@ -35,14 +34,12 @@ class AsynchronousDeliveryStampTest extends TestCase
     {
         $data = ['identifier' => 'array_id'];
         $stamp = AsynchronousDeliveryStamp::fromArray($data);
-        $this->assertInstanceOf(AsynchronousDeliveryStamp::class, $stamp);
         $this->assertSame('array_id', $stamp->identifier);
     }
 
     public function testCreateWithRandomId(): void
     {
         $stamp = AsynchronousDeliveryStamp::createWithRandomId();
-        $this->assertInstanceOf(AsynchronousDeliveryStamp::class, $stamp);
         $this->assertSame(64, \strlen($stamp->identifier));
         $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $stamp->identifier);
     }


### PR DESCRIPTION
See https://github.com/terminal42/extensions-docs/pull/9 for docs.

This should allow to create something like this for the Notification Center Pro 💰 😎 

<img width="1032" alt="Bildschirmfoto 2025-04-23 um 15 41 35" src="https://github.com/user-attachments/assets/cbe59176-0246-4f0c-9532-9ad574b8f6ad" />
