### PR TITLE
Allow TranslatableInterface for token translation

### DIFF
--- a/assets/autosuggester.js
+++ b/assets/autosuggester.js
@@ -55,7 +55,6 @@ application.register(
                 if (window.tinyMCE) {
                     try {
                         this.tinyMCEInstance = window.tinyMCE.get(this.element.id);
-                        // eslint-disable-next-line no-unused-vars
                     } catch (err) {
                         // ignore error
                     }

--- a/src/Backend/AutoSuggester.php
+++ b/src/Backend/AutoSuggester.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Terminal42\NotificationCenterBundle\Backend;
 
 use Symfony\Component\Asset\Packages;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
 
@@ -48,9 +49,11 @@ class AutoSuggester
         $tokens = [];
 
         foreach ($this->notificationCenter->getTokenDefinitionsForNotificationType($notificationType, $context) as $token) {
-            $label = '';
+            $translationKey = $token->getTranslationKey();
 
-            if (($translationKey = $token->getTranslationKey()) !== null) {
+            if ($translationKey instanceof TranslatableInterface) {
+                $label = $translationKey->trans($this->translator);
+            } else {
                 $translationKey = 'nc_tokens.'.$translationKey;
                 $label = $this->translator->trans($translationKey, [], 'contao_nc_tokens');
 

--- a/src/Token/Definition/AbstractTokenDefinition.php
+++ b/src/Token/Definition/AbstractTokenDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Terminal42\NotificationCenterBundle\Token\Definition;
 
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Terminal42\NotificationCenterBundle\Parcel\StampCollection;
 use Terminal42\NotificationCenterBundle\Token\Token;
 
@@ -11,7 +12,7 @@ abstract class AbstractTokenDefinition implements TokenDefinitionInterface
 {
     final public function __construct(
         private readonly string $tokenName,
-        private readonly string $translationKey,
+        private readonly string|TranslatableInterface $translationKey,
     ) {
     }
 
@@ -20,7 +21,7 @@ abstract class AbstractTokenDefinition implements TokenDefinitionInterface
         return $this->tokenName;
     }
 
-    public function getTranslationKey(): string
+    public function getTranslationKey(): string|TranslatableInterface
     {
         return $this->translationKey;
     }

--- a/src/Token/Definition/AbstractTokenDefinition.php
+++ b/src/Token/Definition/AbstractTokenDefinition.php
@@ -12,7 +12,7 @@ abstract class AbstractTokenDefinition implements TokenDefinitionInterface
 {
     final public function __construct(
         private readonly string $tokenName,
-        private readonly string|TranslatableInterface $translationKey,
+        private readonly TranslatableInterface|string $translationKey,
     ) {
     }
 
@@ -21,7 +21,7 @@ abstract class AbstractTokenDefinition implements TokenDefinitionInterface
         return $this->tokenName;
     }
 
-    public function getTranslationKey(): string|TranslatableInterface
+    public function getTranslationKey(): TranslatableInterface|string
     {
         return $this->translationKey;
     }

--- a/src/Token/Definition/TokenDefinitionInterface.php
+++ b/src/Token/Definition/TokenDefinitionInterface.php
@@ -23,7 +23,7 @@ interface TokenDefinitionInterface
      * will search for the translation key "nc_tokens.form.foobar" in the
      * "contao_nc_tokens" domain.
      */
-    public function getTranslationKey(): string|TranslatableInterface;
+    public function getTranslationKey(): TranslatableInterface|string;
 
     /**
      * Should return true if the token definition is responsible for a given token

--- a/src/Token/Definition/TokenDefinitionInterface.php
+++ b/src/Token/Definition/TokenDefinitionInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Terminal42\NotificationCenterBundle\Token\Definition;
 
+use Symfony\Contracts\Translation\TranslatableInterface;
 use Terminal42\NotificationCenterBundle\Parcel\StampCollection;
 use Terminal42\NotificationCenterBundle\Token\Token;
 
@@ -22,7 +23,7 @@ interface TokenDefinitionInterface
      * will search for the translation key "nc_tokens.form.foobar" in the
      * "contao_nc_tokens" domain.
      */
-    public function getTranslationKey(): string;
+    public function getTranslationKey(): string|TranslatableInterface;
 
     /**
      * Should return true if the token definition is responsible for a given token


### PR DESCRIPTION
Notification Center currently hardcodes the translations to live in the `contao_nc_tokens` translation file. By allowing a `TranslatableInterface`, developers can either go with the default, or decide on their own translation using e.g. `TranslatableMessage` including their own translation parameters.

Btw. I also noticed that `getTranslationKey` can never be null, therefore removed the null check in the `AutoSuggester`.