### PR TITLE
Always initialize the module configs

### DIFF
--- a/contao/dca/tl_module.php
+++ b/contao/dca/tl_module.php
@@ -2,8 +2,46 @@
 
 declare(strict_types=1);
 
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
 $GLOBALS['TL_DCA']['tl_module']['palettes']['__selector__'][] = 'nc_registration_auto_activate';
+$GLOBALS['TL_DCA']['tl_module']['palettes']['lostPasswordNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['lostPassword'];
+$GLOBALS['TL_DCA']['tl_module']['palettes']['registrationNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['registration'];
 $GLOBALS['TL_DCA']['tl_module']['subpalettes']['nc_registration_auto_activate'] = 'reg_jumpTo,nc_activation_notification';
+
+PaletteManipulator::create()
+    ->addField('nc_notification', 'reg_password', PaletteManipulator::POSITION_BEFORE)
+    ->addField('nc_lost_password_jumpTo', 'email_legend', PaletteManipulator::POSITION_PREPEND)
+    ->removeField('reg_password')
+    ->applyToPalette('lostPasswordNotificationCenter', 'tl_module')
+;
+
+PaletteManipulator::create()
+    ->addField('nc_notification', 'reg_activate')
+    ->addField('nc_registration_auto_activate', 'nc_notification')
+    ->removeField('reg_activate')
+    ->applyToPalette('registrationNotificationCenter', 'tl_module')
+;
+
+PaletteManipulator::create()
+    ->addField('nc_notification', 'config_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('personalData', 'tl_module')
+;
+
+// ContaoNewsletterBundle must be installed
+if (isset($GLOBALS['TL_DCA']['tl_module']['palettes']['subscribe'])) {
+    $GLOBALS['TL_DCA']['tl_module']['palettes']['newsletterSubscribeNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['subscribe'];
+    $GLOBALS['TL_DCA']['tl_module']['palettes']['newsletterUnsubscribeNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['unsubscribe'];
+
+    PaletteManipulator::create()
+        ->addField('nc_notification', 'email_legend', PaletteManipulator::POSITION_APPEND)
+        ->removeField('nl_subscribe')
+        ->applyToPalette('newsletterUnsubscribeNotificationCenter', 'tl_module')
+        ->addField('nc_activation_notification', 'nc_notification')
+        ->addField('nc_newsletter_activation_jumpTo', 'redirect_legend', PaletteManipulator::POSITION_APPEND)
+        ->applyToPalette('newsletterSubscribeNotificationCenter', 'tl_module')
+    ;
+}
 
 $GLOBALS['TL_DCA']['tl_module']['fields']['nc_notification'] = [
     'exclude' => true,

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -9,6 +9,7 @@ use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
+use Contao\NewsletterBundle\ContaoNewsletterBundle;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Terminal42\NotificationCenterBundle\Terminal42NotificationCenterBundle;
@@ -20,7 +21,7 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
         return [
             (new BundleConfig(Terminal42NotificationCenterBundle::class))
                 ->setReplace(['notification_center'])
-                ->setLoadAfter([ContaoCoreBundle::class]),
+                ->setLoadAfter([ContaoCoreBundle::class, ContaoNewsletterBundle::class]),
         ];
     }
 

--- a/src/EventListener/Backend/DataContainer/ModuleListener.php
+++ b/src/EventListener/Backend/DataContainer/ModuleListener.php
@@ -23,7 +23,7 @@ class ModuleListener
     #[AsCallback(table: 'tl_module', target: 'fields.nc_notification.attributes')]
     public function onAttributesCallback(array $attributes, DataContainer $dc): array
     {
-        if ($dc->getCurrentRecord()['type'] === 'newsletterSubscribeNotificationCenter') {
+        if ('newsletterSubscribeNotificationCenter' === $dc->getCurrentRecord()['type']) {
             $attributes['mandatory'] = true;
         }
 

--- a/src/EventListener/Backend/DataContainer/ModuleListener.php
+++ b/src/EventListener/Backend/DataContainer/ModuleListener.php
@@ -22,6 +22,7 @@ class ModuleListener
 
     /**
      * @param array<string, mixed> $attributes
+     *
      * @return array<string, mixed>
      */
     #[AsCallback(table: 'tl_module', target: 'fields.nc_notification.attributes')]

--- a/src/EventListener/Backend/DataContainer/ModuleListener.php
+++ b/src/EventListener/Backend/DataContainer/ModuleListener.php
@@ -20,6 +20,10 @@ class ModuleListener
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $attributes
+     * @return array<string, mixed>
+     */
     #[AsCallback(table: 'tl_module', target: 'fields.nc_notification.attributes')]
     public function onAttributesCallback(array $attributes, DataContainer $dc): array
     {

--- a/src/EventListener/Backend/DataContainer/ModuleListener.php
+++ b/src/EventListener/Backend/DataContainer/ModuleListener.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Terminal42\NotificationCenterBundle\EventListener\Backend\DataContainer;
 
-use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\DataContainer;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -21,30 +20,14 @@ class ModuleListener
     ) {
     }
 
-    #[AsCallback(table: 'tl_module', target: 'config.onload')]
-    public function onLoadCallback(DataContainer $dc): void
+    #[AsCallback(table: 'tl_module', target: 'fields.nc_notification.attributes')]
+    public function onAttributesCallback(array $attributes, DataContainer $dc): array
     {
-        if (null === ($moduleConfig = $this->configLoader->loadModule((int) $dc->id))) {
-            return;
+        if ($dc->getCurrentRecord()['type'] === 'newsletterSubscribeNotificationCenter') {
+            $attributes['mandatory'] = true;
         }
 
-        switch ($moduleConfig->getType()) {
-            case 'lostPasswordNotificationCenter':
-                $this->handleLostPasswordModule();
-                break;
-            case 'registrationNotificationCenter':
-                $this->handleRegistrationModule();
-                break;
-            case 'personalData':
-                $this->handlePersonalDataModule();
-                break;
-            case 'newsletterSubscribeNotificationCenter':
-                $this->handleNewsletterSubscribeModule();
-                break;
-            case 'newsletterUnsubscribeNotificationCenter':
-                $this->handleNewsletterUnubscribeModule();
-                break;
-        }
+        return $attributes;
     }
 
     /**
@@ -67,62 +50,5 @@ class ModuleListener
         }
 
         return [];
-    }
-
-    private function handleLostPasswordModule(): void
-    {
-        $GLOBALS['TL_DCA']['tl_module']['palettes']['lostPasswordNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['lostPassword'];
-
-        PaletteManipulator::create()
-            ->addField('nc_notification', 'reg_password', PaletteManipulator::POSITION_BEFORE)
-            ->addField('nc_lost_password_jumpTo', 'email_legend', PaletteManipulator::POSITION_PREPEND)
-            ->removeField('reg_password')
-            ->applyToPalette('lostPasswordNotificationCenter', 'tl_module')
-        ;
-    }
-
-    private function handleRegistrationModule(): void
-    {
-        $GLOBALS['TL_DCA']['tl_module']['palettes']['registrationNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['registration'];
-
-        PaletteManipulator::create()
-            ->addField('nc_notification', 'reg_activate')
-            ->addField('nc_registration_auto_activate', 'nc_notification')
-            ->removeField('reg_activate')
-            ->applyToPalette('registrationNotificationCenter', 'tl_module')
-        ;
-    }
-
-    private function handlePersonalDataModule(): void
-    {
-        PaletteManipulator::create()
-            ->addField('nc_notification', 'config_legend', PaletteManipulator::POSITION_APPEND)
-            ->applyToPalette('personalData', 'tl_module')
-        ;
-    }
-
-    private function handleNewsletterSubscribeModule(): void
-    {
-        $GLOBALS['TL_DCA']['tl_module']['palettes']['newsletterSubscribeNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['subscribe'];
-        $GLOBALS['TL_DCA']['tl_module']['fields']['nc_notification']['eval']['mandatory'] = true;
-
-        PaletteManipulator::create()
-            ->addField('nc_notification', 'email_legend', PaletteManipulator::POSITION_APPEND)
-            ->addField('nc_activation_notification', 'nc_notification')
-            ->addField('nc_newsletter_activation_jumpTo', 'redirect_legend', PaletteManipulator::POSITION_APPEND)
-            ->removeField('nl_subscribe')
-            ->applyToPalette('newsletterSubscribeNotificationCenter', 'tl_module')
-        ;
-    }
-
-    private function handleNewsletterUnubscribeModule(): void
-    {
-        $GLOBALS['TL_DCA']['tl_module']['palettes']['newsletterUnsubscribeNotificationCenter'] = $GLOBALS['TL_DCA']['tl_module']['palettes']['unsubscribe'];
-
-        PaletteManipulator::create()
-            ->addField('nc_notification', 'email_legend', PaletteManipulator::POSITION_APPEND)
-            ->removeField('nl_unsubscribe')
-            ->applyToPalette('newsletterUnsubscribeNotificationCenter', 'tl_module')
-        ;
     }
 }


### PR DESCRIPTION
The module palettes are currently only loaded based on the _current_ module type in `onload_callback`, but this means there is no palettes in list view where there is no "current" module. There's no reason to not always load the palettes, except for the mandatory check which should be done in `attributes` callback. This now also works in edit-all mode where you can edit different types of modules and get the correct mandatory check.