### PR TITLE
Add file paths to form tokens

### DIFF
--- a/contao/languages/de/nc_tokens.xlf
+++ b/contao/languages/de/nc_tokens.xlf
@@ -14,6 +14,10 @@
         <source>All the form fields.</source>
         <target>Alle Formularfelder.</target>
       </trans-unit>
+      <trans-unit id="nc_tokens.form.file_*">
+        <source>File paths for upload form fields.</source>
+        <target>Dateipfade für Upload-Formularfelder.</target>
+      </trans-unit>
       <trans-unit id="nc_tokens.form.formlabel_*">
         <source>All the form field labels.</source>
         <target>Alle Formularfeld-Labels.</target>

--- a/contao/languages/en/nc_tokens.xlf
+++ b/contao/languages/en/nc_tokens.xlf
@@ -14,6 +14,10 @@
         <source>All the form fields.</source>
         <target>All the form fields.</target>
       </trans-unit>
+      <trans-unit id="nc_tokens.form.file_*">
+        <source>File paths for upload form fields.</source>
+        <target>File paths for upload form fields.</target>
+      </trans-unit>
       <trans-unit id="nc_tokens.form.formlabel_*">
         <source>All the form field labels.</source>
         <target>All the form field labels.</target>

--- a/src/EventListener/ProcessFormDataListener.php
+++ b/src/EventListener/ProcessFormDataListener.php
@@ -74,6 +74,7 @@ class ProcessFormDataListener
         $tokens['html_data_filled'] = implode('<br>', $rawDataFilled);
 
         foreach ($this->fileUploadNormalizer->normalize($files) as $k => $files) {
+            $paths = [];
             $vouchers = [];
 
             foreach ($files as $file) {
@@ -82,9 +83,11 @@ class ProcessFormDataListener
                     FileItem::fromPath($file['tmp_name'], $file['name'], $file['type'], $file['size']);
 
                 $vouchers[] = $this->notificationCenter->getBulkyItemStorage()->store($fileItem);
+                $paths[] = $file['tmp_name'];
             }
 
             $tokens['form_'.$k] = implode(',', $vouchers);
+            $tokens['file_'.$k] = implode(',', $paths);
             $bulkyItemVouchers = array_merge($bulkyItemVouchers, $vouchers);
         }
 

--- a/src/NotificationType/FormGeneratorNotificationType.php
+++ b/src/NotificationType/FormGeneratorNotificationType.php
@@ -26,6 +26,7 @@ class FormGeneratorNotificationType implements NotificationTypeInterface
     {
         return [
             $this->factory->create(AnythingTokenDefinition::class, 'form_*', 'form.form_*'),
+            $this->factory->create(AnythingTokenDefinition::class, 'file_*', 'form.file_*'),
             $this->factory->create(AnythingTokenDefinition::class, 'formconfig_*', 'form.formconfig_*'),
             $this->factory->create(AnythingTokenDefinition::class, 'formlabel_*', 'form.formlabel_*'),
             $this->factory->create(TextTokenDefinition::class, 'raw_data', 'form.raw_data'),


### PR DESCRIPTION
In NC 1.x, if `xxx` was a file upload field, the `form_xxx` would contain the path to the uploaded file. In NC2 this now contains the voucher for bulky items storage.

This PR re-adds a simple token for the file path, because sometimes you don't want to send the file by email but store it on the server and get the path by email (e.g. for manual download, secure contract review etc.).

I have manually tested this and it seems to work flawlessly. If you do not check "Store files" in the form generator, the email will contain the temporary PHP path (which makes no sense but shouldn't harm).