### PR TITLE
Add domain to the newsletter tokens

### DIFF
--- a/config/newsletter_bundle.php
+++ b/config/newsletter_bundle.php
@@ -51,6 +51,7 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             service(NotificationCenter::class),
             service('contao.framework'),
+            service('request_stack'),
         ])
     ;
 };

--- a/contao/languages/de/nc_tokens.xlf
+++ b/contao/languages/de/nc_tokens.xlf
@@ -66,6 +66,30 @@
         <source>Unformatted data of the member.</source>
         <target>Unformatierte Daten des Mitglieds.</target>
       </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.recipient_email">
+        <source>E-mail of the newsletter recipient.</source>
+        <target>E-Mail Adresse des Newsletter-Empfängers.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.link">
+        <source>Activation link for the newsletter.</source>
+        <target>Aktivierungslink für die Newsletter-Anmeldung.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.token">
+        <source>Activation token, if you want to build the activation link yourself.</source>
+        <target>Aktivierungs-Token, um die Aktivierungs-URL selber zu bauen.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.domain">
+        <source>Domain where the newsletter form was subscribed to.</source>
+        <target>Domain unter welcher die Newsletter-Anmeldung vorgenommen wurde.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.channels">
+        <source>Comma-separated list of the subscribed newsletter channels.</source>
+        <target>Komma-getrennte Liste der angemeldeten Newsletter-Kanäle.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.channel_ids">
+        <source>Comma-separated list of the subscribed newsletter channel IDs.</source>
+        <target>Komma-getrennte Liste der IDs angemeldeten Newsletter-Kanäle.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/contao/languages/en/nc_tokens.xlf
+++ b/contao/languages/en/nc_tokens.xlf
@@ -66,6 +66,30 @@
         <source>Unformatted data of the member.</source>
         <target>Unformatted data of the member.</target>
       </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.recipient_email">
+        <source>E-mail of the newsletter recipient.</source>
+        <target>E-mail of the newsletter recipient.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.link">
+        <source>Activation link for the newsletter.</source>
+        <target>Activation link for the newsletter.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.token">
+        <source>Activation token, if you want to build the activation link yourself.</source>
+        <target>Activation token, if you want to build the activation link yourself.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.domain">
+        <source>Domain where the newsletter form was subscribed to.</source>
+        <target>Domain where the newsletter form was subscribed to.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.channels">
+        <source>Comma-separated list of the subscribed newsletter channels.</source>
+        <target>Comma-separated list of the subscribed newsletter channels.</target>
+      </trans-unit>
+      <trans-unit id="nc_tokens.newsletter.channel_ids">
+        <source>Comma-separated list of the subscribed newsletter channel IDs.</source>
+        <target>Comma-separated list of the subscribed newsletter channel IDs.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Controller/FrontendModule/Newsletter/SubscribeController.php
+++ b/src/Controller/FrontendModule/Newsletter/SubscribeController.php
@@ -14,21 +14,30 @@ use Contao\NewsletterDenyListModel;
 use Contao\NewsletterRecipientsModel;
 use Contao\PageModel;
 use Contao\System;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
 
 #[AsFrontendModule('newsletterSubscribeNotificationCenter', 'newsletter', 'nl_default')]
 class SubscribeController extends ModuleSubscribe
 {
+    private Request|null $request = null;
+
     public function __construct(private readonly NotificationCenter $notificationCenter)
     {
     }
 
-    public function __invoke(ModuleModel $model, string $section): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section): Response
     {
         parent::__construct($model, $section);
 
-        return new Response($this->generate());
+        $this->request = $request;
+
+        $content = $this->generate();
+
+        $this->request = null;
+
+        return new Response($content);
     }
 
     /**
@@ -76,6 +85,7 @@ class SubscribeController extends ModuleSubscribe
         $tokens['recipient_email'] = $strEmail;
         $tokens['token'] = $optInToken->getIdentifier();
         $tokens['link'] = Idna::decode(Environment::get('url')).Environment::get('requestUri').(str_contains((string) Environment::get('requestUri'), '?') ? '&' : '?').'token='.$optInToken->getIdentifier();
+        $tokens['domain'] = $this->request?->getHost() ?? '';
         $tokens['channels'] = implode(', ', $arrChannels);
         $tokens['channel_ids'] = implode(', ', $arrNew);
 

--- a/src/Controller/FrontendModule/Newsletter/UnsubscribeController.php
+++ b/src/Controller/FrontendModule/Newsletter/UnsubscribeController.php
@@ -12,21 +12,30 @@ use Contao\NewsletterDenyListModel;
 use Contao\NewsletterRecipientsModel;
 use Contao\PageModel;
 use Contao\System;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
 
 #[AsFrontendModule('newsletterUnsubscribeNotificationCenter', 'newsletter', 'nl_default')]
 class UnsubscribeController extends ModuleUnsubscribe
 {
+    private Request|null $request = null;
+
     public function __construct(private readonly NotificationCenter $notificationCenter)
     {
     }
 
-    public function __invoke(ModuleModel $model, string $section): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section): Response
     {
         parent::__construct($model, $section);
 
-        return new Response($this->generate());
+        $this->request = $request;
+
+        $content = $this->generate();
+
+        $this->request = null;
+
+        return new Response($content);
     }
 
     /**
@@ -67,6 +76,7 @@ class UnsubscribeController extends ModuleUnsubscribe
         // Prepare the simple tokens
         $tokens = [];
         $tokens['recipient_email'] = $strEmail;
+        $tokens['domain'] = $this->request?->getHost() ?? '';
         $tokens['channels'] = implode(', ', $arrChannels);
         $tokens['channel_ids'] = implode(', ', $arrRemove);
 

--- a/src/EventListener/Newsletter/ActivationListener.php
+++ b/src/EventListener/Newsletter/ActivationListener.php
@@ -11,6 +11,7 @@ use Contao\Module;
 use Contao\ModuleSubscribe;
 use Contao\NewsletterChannelModel;
 use Contao\PageModel;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Terminal42\NotificationCenterBundle\NotificationCenter;
 
 #[AsHook('activateRecipient')]
@@ -19,6 +20,7 @@ class ActivationListener
     public function __construct(
         private readonly NotificationCenter $notificationCenter,
         private readonly ContaoFramework $contaoFramework,
+        private readonly RequestStack $requestStack,
     ) {
     }
 
@@ -62,6 +64,7 @@ class ActivationListener
         // Prepare the simple tokens
         $tokens = [];
         $tokens['recipient_email'] = $email;
+        $tokens['domain'] = $this->requestStack->getCurrentRequest()?->getHost() ?? '';
         $tokens['channels'] = implode(', ', $channelTitles);
         $tokens['channel_ids'] = implode(', ', $channelIds);
 

--- a/src/NotificationType/Newsletter/NewsletterActivateNotificationType.php
+++ b/src/NotificationType/Newsletter/NewsletterActivateNotificationType.php
@@ -26,6 +26,7 @@ class NewsletterActivateNotificationType implements NotificationTypeInterface
     {
         return [
             $this->factory->create(EmailTokenDefinition::class, 'recipient_email', 'newsletter.recipient_email'),
+            $this->factory->create(TextTokenDefinition::class, 'domain', 'newsletter.domain'),
             $this->factory->create(TextTokenDefinition::class, 'channels', 'newsletter.channels'),
             $this->factory->create(TextTokenDefinition::class, 'channel_ids', 'newsletter.channel_ids'),
         ];

--- a/src/NotificationType/Newsletter/NewsletterSubscribeNotificationType.php
+++ b/src/NotificationType/Newsletter/NewsletterSubscribeNotificationType.php
@@ -28,6 +28,7 @@ class NewsletterSubscribeNotificationType implements NotificationTypeInterface
             $this->factory->create(EmailTokenDefinition::class, 'recipient_email', 'newsletter.recipient_email'),
             $this->factory->create(TextTokenDefinition::class, 'link', 'newsletter.link'),
             $this->factory->create(TextTokenDefinition::class, 'token', 'newsletter.token'),
+            $this->factory->create(TextTokenDefinition::class, 'domain', 'newsletter.domain'),
             $this->factory->create(TextTokenDefinition::class, 'channels', 'newsletter.channels'),
             $this->factory->create(TextTokenDefinition::class, 'channel_ids', 'newsletter.channel_ids'),
         ];

--- a/src/NotificationType/Newsletter/NewsletterUnsubscribeNotificationType.php
+++ b/src/NotificationType/Newsletter/NewsletterUnsubscribeNotificationType.php
@@ -26,6 +26,7 @@ class NewsletterUnsubscribeNotificationType implements NotificationTypeInterface
     {
         return [
             $this->factory->create(EmailTokenDefinition::class, 'recipient_email', 'newsletter.recipient_email'),
+            $this->factory->create(TextTokenDefinition::class, 'domain', 'newsletter.domain'),
             $this->factory->create(TextTokenDefinition::class, 'channels', 'newsletter.channels'),
             $this->factory->create(TextTokenDefinition::class, 'channel_ids', 'newsletter.channel_ids'),
         ];


### PR DESCRIPTION
Contao core provides a `##domain##` simple token for the newsletter subscription. This token was also available in Notification Center v1. This PR re-adds it, including translations for the newsletter tokens.

Manually tested everything on a client system.