### PR TITLE
Add UnicodeString to content disposition header

### DIFF
--- a/src/Controller/DownloadBulkyItemController.php
+++ b/src/Controller/DownloadBulkyItemController.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\String\UnicodeString;
 use Symfony\Component\HttpFoundation\UriSigner as HttpFoundationUriSigner;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Terminal42\NotificationCenterBundle\BulkyItem\BulkyItemStorage;
@@ -47,6 +48,7 @@ class DownloadBulkyItemController
         $response->headers->set('Content-Disposition', HeaderUtils::makeDisposition(
             HeaderUtils::DISPOSITION_ATTACHMENT,
             $bulkyItem->getName(),
+            (new UnicodeString($bulkyItem->getName()))->ascii()->toString(),
         ));
 
         return $response;


### PR DESCRIPTION
Fixes a problem with filename with characters like äöüÄÖÜß

Added with support from fritzmg & andyschempp and copied from https://github.com/terminal42/contao-leads/blob/main/src/Export/AbstractExporter.php#L66